### PR TITLE
[No ticket] - Refactor assignments page into table

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -24,6 +24,14 @@ type Props = {
   tableHeight?: string;
 };
 
+export const ClickableRowPropsConfiguration = {
+  style: {
+    cursor: 'pointer',
+    transition: 'background-color 0.8s',
+  },
+  _hover: { bg: theme.colors.teachHub.gray },
+};
+
 export default (props: Props) => {
   return (
     <Box

--- a/src/pages/courses/assignments/index.tsx
+++ b/src/pages/courses/assignments/index.tsx
@@ -1,27 +1,25 @@
-import { Suspense } from 'react';
-import { Link as ReachLink, useNavigate } from 'react-router-dom';
+import React, { Suspense } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useLazyLoadQuery } from 'react-relay';
 
-import { AddIcon } from '@chakra-ui/icons';
+import { Icon } from '@chakra-ui/icons';
 
 import CourseAssignmentsQueryDef from 'graphql/CourseAssignmentsQuery';
-import { Flex, Link, ListItem } from '@chakra-ui/react';
-import { TasklistIcon } from '@primer/octicons-react';
 
-import { formatAsSimpleDate } from 'utils/dates';
+import { formatAsSimpleDateTime } from 'utils/dates';
 
 import { Permission, useUserContext } from 'hooks/useUserCourseContext';
 
 import PageDataContainer from 'components/PageDataContainer';
-import List from 'components/list/List';
 import Navigation from 'components/Navigation';
-import Box from 'components/Box';
-import IconButton from 'components/IconButton';
-import ListIcon from 'components/list/ListIcon';
-import Text from 'components/Text';
 import Heading from 'components/Heading';
 
 import type { CourseAssignmentsQuery } from '__generated__/CourseAssignmentsQuery.graphql';
+import Button from 'components/Button';
+import { Flex, Stack } from '@chakra-ui/react';
+import Text from 'components/Text';
+import { PlusIcon } from '@primer/octicons-react';
+import Table, { ClickableRowPropsConfiguration } from 'components/Table';
 
 const AssignmentsPage = () => {
   const navigate = useNavigate();
@@ -32,40 +30,42 @@ const AssignmentsPage = () => {
   });
 
   const assignments = data.viewer?.course?.assignments || [];
-  const hasAssignments = assignments.length !== 0;
 
   return (
     <PageDataContainer>
-      <Heading>{'Trabajos Prácticos'}</Heading>
-      <Flex paddingY={'30px'}>
-        {hasAssignments ? (
-          <List>
-            {assignments.map(data => (
-              <ListItem key={data.id}>
-                <ListIcon icon={TasklistIcon} />
-                <Link as={ReachLink} to={`${data.id}`}>
-                  <span style={{ fontWeight: 'bold' }}>{data.title}</span>
-                </Link>
-                {data.endDate ? ` (${formatAsSimpleDate(data.endDate)})` : ''}
-              </ListItem>
-            ))}
-          </List>
-        ) : (
-          <Text>{'Aún no se ha creado ningún trabajo práctico'}</Text>
+      <Flex direction="row" gap={'20px'} align={'center'}>
+        <Heading>{'Trabajos Prácticos'}</Heading>
+        {courseContext.userHasPermission(Permission.CreateAssignment) && (
+          <Button
+            variant={'ghostBorder'}
+            onClick={() => navigate(`create`)}
+            width={'fit-content'}
+          >
+            <Flex align="center">
+              <Icon as={PlusIcon} boxSize={6} marginRight={2} />
+              <Text>Crear</Text>
+            </Flex>
+          </Button>
         )}
       </Flex>
 
-      {courseContext.userHasPermission(Permission.CreateAssignment) && (
-        <Box position="fixed" bottom="30px" right="30px">
-          <IconButton
-            icon={<AddIcon boxSize={'50%'} />}
-            boxSize={'65px'}
-            borderRadius={'full'}
-            aria-label="Add"
-            onClick={() => navigate(`create`)}
-          />
-        </Box>
-      )}
+      <Stack gap={'30px'} marginTop={'10px'}>
+        <Table
+          headers={['Título', 'Fecha límite entrega']}
+          rowOptions={assignments.map(data => {
+            return {
+              rowProps: {
+                ...ClickableRowPropsConfiguration,
+                onClick: () => navigate(data.id),
+              },
+              content: [
+                `${data.title}`,
+                `${data.endDate ? `${formatAsSimpleDateTime(data.endDate)}` : '-'}`,
+              ],
+            };
+          })}
+        />
+      </Stack>
     </PageDataContainer>
   );
 };

--- a/src/pages/courses/assignments/index.tsx
+++ b/src/pages/courses/assignments/index.tsx
@@ -15,11 +15,11 @@ import Navigation from 'components/Navigation';
 import Heading from 'components/Heading';
 
 import type { CourseAssignmentsQuery } from '__generated__/CourseAssignmentsQuery.graphql';
-import Button from 'components/Button';
 import { Flex, Stack } from '@chakra-ui/react';
-import Text from 'components/Text';
 import { PlusIcon } from '@primer/octicons-react';
 import Table, { ClickableRowPropsConfiguration } from 'components/Table';
+import Button from 'components/Button';
+import Text from 'components/Text';
 
 const AssignmentsPage = () => {
   const navigate = useNavigate();
@@ -60,7 +60,7 @@ const AssignmentsPage = () => {
               },
               content: [
                 `${data.title}`,
-                `${data.endDate ? `${formatAsSimpleDateTime(data.endDate)}` : '-'}`,
+                data.endDate ? formatAsSimpleDateTime(data.endDate) : '-',
               ],
             };
           })}

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -51,6 +51,12 @@ export const theme = extendTheme({
           color: 'teachHub.black',
           _hover: { bg: 'teachHub.white' },
         },
+        ghostBorder: {
+          color: 'teachHub.black',
+          _hover: { bg: 'teachHub.white' },
+          borderColor: 'teachHub.black',
+          borderWidth: 2,
+        },
       },
     },
   },


### PR DESCRIPTION
![image](https://github.com/teach-hub/frontoffice/assets/31221128/180fe0f0-a7ff-4f9d-b80a-db03c57281ee)

Unifica formato de listado de recursos y tambien puede simplificar para manejar entregas de forma general para los trabajos practicos, o de forma individual de cada una (cada fila es clickeable, y se podria agregar una ultima columna de acciones, como para ir a las entregas de un tp sin tener que ir cada vez al detalle, o del lado de alumnos la accion de crear una entrega, de complicarse sumarla al boton de acciones del navegador)