### PR TITLE
TH-192 Create repositories by assignment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,16 +97,6 @@ const App = () => {
           >
             <Route index element={<CoursePage />} />
             <Route path="users" element={<CourseUsersPage />} />
-            <Route path="new-repo">
-              <Route
-                path="students"
-                element={<CreateRepository type={RepositoryType.Students} />}
-              />
-              <Route
-                path="groups"
-                element={<CreateRepository type={RepositoryType.Groups} />}
-              />
-            </Route>
             <Route path="add-submission" element={<AddSubmissionPage />} />
             <Route path="my-groups" element={<MyGroups />} />
             <Route path="assignments">
@@ -117,6 +107,16 @@ const App = () => {
                 <Route path="assign-reviewers" element={<AssignReviewersPage />} />
                 <Route path="edit" element={<CreateOrUpdateAssignmentsPage />} />
                 <Route path="add-submission" element={<AddSubmissionPage />} />
+                <Route path="new-repo">
+                  <Route
+                    path="students"
+                    element={<CreateRepository type={RepositoryType.Students} />}
+                  />
+                  <Route
+                    path="groups"
+                    element={<CreateRepository type={RepositoryType.Groups} />}
+                  />
+                </Route>
               </Route>
             </Route>
             <Route

--- a/src/__generated__/CourseAssignmentsQuery.graphql.ts
+++ b/src/__generated__/CourseAssignmentsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<59b04848b828cc49e75d08e9da9a6554>>
+ * @generated SignedSource<<442ebf70744fb311b797cd56b2254963>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,6 +18,7 @@ export type CourseAssignmentsQuery$data = {
       readonly assignments: ReadonlyArray<{
         readonly endDate: string | null;
         readonly id: string;
+        readonly isGroup: boolean | null;
         readonly title: string | null;
       }>;
       readonly id: string;
@@ -100,6 +101,13 @@ v2 = [
                 "kind": "ScalarField",
                 "name": "endDate",
                 "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isGroup",
+                "storageKey": null
               }
             ],
             "storageKey": null
@@ -129,16 +137,16 @@ return {
     "selections": (v2/*: any*/)
   },
   "params": {
-    "cacheID": "9c31873fa02da03b0dae6a3996779b21",
+    "cacheID": "944c64cedc5d184f4e4c96900d0a9d74",
     "id": null,
     "metadata": {},
     "name": "CourseAssignmentsQuery",
     "operationKind": "query",
-    "text": "query CourseAssignmentsQuery(\n  $courseId: ID!\n) {\n  viewer {\n    id\n    name\n    course(id: $courseId) {\n      id\n      assignments {\n        id\n        title\n        endDate\n      }\n    }\n  }\n}\n"
+    "text": "query CourseAssignmentsQuery(\n  $courseId: ID!\n) {\n  viewer {\n    id\n    name\n    course(id: $courseId) {\n      id\n      assignments {\n        id\n        title\n        endDate\n        isGroup\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "251a1b101c5abce66b49a72fa68a96aa";
+(node as any).hash = "73bf7502f0a27261ed4a9023369c0848";
 
 export default node;

--- a/src/__generated__/CourseCreateRepositoryQuery.graphql.ts
+++ b/src/__generated__/CourseCreateRepositoryQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<839450c9a739ba3a93b096f9639f7a4c>>
+ * @generated SignedSource<<773ac31d71a3f297d07316b342184732>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,28 +10,28 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 export type CourseCreateRepositoryQuery$variables = {
+  assignmentId: string;
   courseId: string;
 };
 export type CourseCreateRepositoryQuery$data = {
   readonly viewer: {
     readonly course: {
       readonly assignments: ReadonlyArray<{
-        readonly id: string;
-        readonly title: string | null;
-      }>;
-      readonly groups: ReadonlyArray<{
-        readonly id: string;
-        readonly name: string | null;
-        readonly usersByAssignments: ReadonlyArray<{
-          readonly assignmentIds: ReadonlyArray<string | null>;
-          readonly users: ReadonlyArray<{
+        readonly groupParticipants: ReadonlyArray<{
+          readonly group: {
+            readonly id: string;
+            readonly name: string | null;
+          };
+          readonly id: string;
+          readonly user: {
             readonly file: string;
             readonly id: string;
             readonly lastName: string;
             readonly name: string;
-            readonly notificationEmail: string;
-          }>;
+          };
         }>;
+        readonly id: string;
+        readonly title: string | null;
       }>;
       readonly id: string;
       readonly name: string;
@@ -63,46 +63,42 @@ export type CourseCreateRepositoryQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = [
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "courseId"
-  }
-],
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "assignmentId"
+},
 v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "courseId"
+},
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v2 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lastName",
   "storageKey": null
 },
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "file",
-  "storageKey": null
-},
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "notificationEmail",
+  "name": "file",
   "storageKey": null
 },
 v6 = [
@@ -114,8 +110,8 @@ v6 = [
     "name": "viewer",
     "plural": false,
     "selections": [
-      (v1/*: any*/),
       (v2/*: any*/),
+      (v3/*: any*/),
       {
         "alias": null,
         "args": [
@@ -130,8 +126,8 @@ v6 = [
         "name": "course",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
           (v2/*: any*/),
+          (v3/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -142,31 +138,12 @@ v6 = [
           {
             "alias": null,
             "args": null,
-            "concreteType": "AssignmentType",
-            "kind": "LinkedField",
-            "name": "assignments",
-            "plural": true,
-            "selections": [
-              (v1/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "title",
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
             "concreteType": "UserRoleType",
             "kind": "LinkedField",
             "name": "userRoles",
             "plural": true,
             "selections": [
-              (v1/*: any*/),
+              (v2/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -175,11 +152,17 @@ v6 = [
                 "name": "user",
                 "plural": false,
                 "selections": [
-                  (v1/*: any*/),
                   (v2/*: any*/),
                   (v3/*: any*/),
                   (v4/*: any*/),
-                  (v5/*: any*/)
+                  (v5/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "notificationEmail",
+                    "storageKey": null
+                  }
                 ],
                 "storageKey": null
               },
@@ -191,8 +174,8 @@ v6 = [
                 "name": "role",
                 "plural": false,
                 "selections": [
-                  (v1/*: any*/),
                   (v2/*: any*/),
+                  (v3/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -215,27 +198,46 @@ v6 = [
           },
           {
             "alias": null,
-            "args": null,
-            "concreteType": "InternalGroupType",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "assignmentId",
+                "variableName": "assignmentId"
+              }
+            ],
+            "concreteType": "AssignmentType",
             "kind": "LinkedField",
-            "name": "groups",
+            "name": "assignments",
             "plural": true,
             "selections": [
-              (v1/*: any*/),
               (v2/*: any*/),
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "InternalGroupUsersByAssignments",
+                "kind": "ScalarField",
+                "name": "title",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "InternalGroupParticipantType",
                 "kind": "LinkedField",
-                "name": "usersByAssignments",
+                "name": "groupParticipants",
                 "plural": true,
                 "selections": [
+                  (v2/*: any*/),
                   {
                     "alias": null,
                     "args": null,
-                    "kind": "ScalarField",
-                    "name": "assignmentIds",
+                    "concreteType": "InternalGroupType",
+                    "kind": "LinkedField",
+                    "name": "group",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/)
+                    ],
                     "storageKey": null
                   },
                   {
@@ -243,14 +245,13 @@ v6 = [
                     "args": null,
                     "concreteType": "UserType",
                     "kind": "LinkedField",
-                    "name": "users",
-                    "plural": true,
+                    "name": "user",
+                    "plural": false,
                     "selections": [
-                      (v1/*: any*/),
                       (v2/*: any*/),
                       (v3/*: any*/),
-                      (v5/*: any*/),
-                      (v4/*: any*/)
+                      (v4/*: any*/),
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -269,7 +270,10 @@ v6 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
     "kind": "Fragment",
     "metadata": null,
     "name": "CourseCreateRepositoryQuery",
@@ -279,22 +283,25 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
     "kind": "Operation",
     "name": "CourseCreateRepositoryQuery",
     "selections": (v6/*: any*/)
   },
   "params": {
-    "cacheID": "d7d50ff2adc3eb0c00b429cfb98f7a68",
+    "cacheID": "84fb6a98cf2807ca07eed8c7c483155c",
     "id": null,
     "metadata": {},
     "name": "CourseCreateRepositoryQuery",
     "operationKind": "query",
-    "text": "query CourseCreateRepositoryQuery(\n  $courseId: ID!\n) {\n  viewer {\n    id\n    name\n    course(id: $courseId) {\n      id\n      name\n      organization\n      assignments {\n        id\n        title\n      }\n      userRoles {\n        id\n        user {\n          id\n          name\n          lastName\n          file\n          notificationEmail\n        }\n        role {\n          id\n          name\n          permissions\n          isTeacher\n        }\n      }\n      groups {\n        id\n        name\n        usersByAssignments {\n          assignmentIds\n          users {\n            id\n            name\n            lastName\n            notificationEmail\n            file\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query CourseCreateRepositoryQuery(\n  $courseId: ID!\n  $assignmentId: ID!\n) {\n  viewer {\n    id\n    name\n    course(id: $courseId) {\n      id\n      name\n      organization\n      userRoles {\n        id\n        user {\n          id\n          name\n          lastName\n          file\n          notificationEmail\n        }\n        role {\n          id\n          name\n          permissions\n          isTeacher\n        }\n      }\n      assignments(assignmentId: $assignmentId) {\n        id\n        title\n        groupParticipants {\n          id\n          group {\n            id\n            name\n          }\n          user {\n            id\n            name\n            lastName\n            file\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "b900d65015e0f2c5ba76dc894ebb988d";
+(node as any).hash = "d9889486894f6713275693eb3eec301b";
 
 export default node;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -100,21 +100,6 @@ const NavigationBar = () => {
     });
   }
 
-  if (courseContext.userHasPermission(Permission.CreateRepository)) {
-    teacherActions.push({
-      content: 'Crear repositorios (individuales)',
-      action: () => {
-        navigate(`/courses/${courseContext.courseId}/new-repo/students`);
-      },
-    });
-    teacherActions.push({
-      content: 'Crear repositorios (grupales)',
-      action: () => {
-        navigate(`/courses/${courseContext.courseId}/new-repo/groups`);
-      },
-    });
-  }
-
   const studentActions = [];
 
   if (courseContext.userHasPermission(Permission.SubmitAssignment)) {

--- a/src/graphql/CourseAssignmentsQuery.tsx
+++ b/src/graphql/CourseAssignmentsQuery.tsx
@@ -11,6 +11,7 @@ export default graphql`
           id
           title
           endDate
+          isGroup
         }
       }
     }

--- a/src/graphql/CourseCreateRepositoryQuery.tsx
+++ b/src/graphql/CourseCreateRepositoryQuery.tsx
@@ -1,7 +1,7 @@
 import { graphql } from 'babel-plugin-relay/macro';
 
 export default graphql`
-  query CourseCreateRepositoryQuery($courseId: ID!) {
+  query CourseCreateRepositoryQuery($courseId: ID!, $assignmentId: ID!) {
     viewer {
       id
       name
@@ -9,10 +9,6 @@ export default graphql`
         id
         name
         organization
-        assignments {
-          id
-          title
-        }
         userRoles {
           id
           user {
@@ -29,16 +25,19 @@ export default graphql`
             isTeacher
           }
         }
-        groups {
+        assignments(assignmentId: $assignmentId) {
           id
-          name
-          usersByAssignments {
-            assignmentIds
-            users {
+          title
+          groupParticipants {
+            id
+            group {
+              id
+              name
+            }
+            user {
               id
               name
               lastName
-              notificationEmail
               file
             }
           }

--- a/src/icons/CreateRepositoryIcon.tsx
+++ b/src/icons/CreateRepositoryIcon.tsx
@@ -1,0 +1,7 @@
+import { IconProps, RepoIcon } from '@primer/octicons-react';
+
+type Props = IconProps;
+
+export default (props: Props) => {
+  return <RepoIcon size="medium" {...props} />;
+};

--- a/src/icons/SubmissionIcon.tsx
+++ b/src/icons/SubmissionIcon.tsx
@@ -1,7 +1,7 @@
-import { IconProps, RepoIcon } from '@primer/octicons-react';
+import { IconProps, ProjectIcon } from '@primer/octicons-react';
 
 type Props = IconProps;
 
 export default (props: Props) => {
-  return <RepoIcon {...props} />;
+  return <ProjectIcon {...props} size="medium" />;
 };

--- a/src/pages/courses/CreateRepository.tsx
+++ b/src/pages/courses/CreateRepository.tsx
@@ -6,7 +6,7 @@ import {
   Stack,
   useDisclosure,
 } from '@chakra-ui/react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import React, { Suspense, useEffect, useState } from 'react';
 import Navigation from 'components/Navigation';
 import Heading from 'components/Heading';
@@ -101,22 +101,13 @@ interface GroupParticipantData {
   file: string;
 }
 
-interface GroupAssignmentData {
-  id: string;
-  title: string;
-}
-
 /**
- * Groups will be displayed in a table, joining the cases where
- * different assignments have the same participants.
- *
- * If a group has different participants for different assignments,
- * then each one will be a different object associated to this interface
+ * Props required for a row in the table
+ * to select repositories to create for groups
  * */
 interface GroupSelectionTableRowProps extends SelectionTableRowProps {
   groupName: string;
   groupId: string;
-  assignments: GroupAssignmentData[];
   participants: GroupParticipantData[];
 }
 
@@ -125,12 +116,14 @@ type CourseType = NonNullable<
 >;
 type UserRoleType = NonNullable<CourseType['userRoles']>[number];
 type AssignmentType = NonNullable<CourseType['assignments']>[number];
-type GroupType = NonNullable<CourseType['groups'][number]>;
-type UsersByAssignmentType = NonNullable<GroupType['usersByAssignments']>;
+type GroupUserType = NonNullable<
+  NonNullable<AssignmentType['groupParticipants']>[number]['user']
+>;
 
 interface GroupUsersData {
-  group: GroupType;
-  usersByAssigment: UsersByAssignmentType;
+  groupId: string;
+  groupName: string;
+  users: GroupUserType[];
 }
 
 /**
@@ -138,14 +131,10 @@ interface GroupUsersData {
  * May differ from students or groups, so a different configuration
  * should be created for each
  *
- * @param title: title of the page
- * @param description: description of the page
  * @param tableHeaders: headers of the table, must not include checkbox
  * @param tableRowData: data for each row of the table
  * */
 interface RepositoriesTypePageConfiguration {
-  title: string;
-  description: string;
   tableHeaders: string[];
   tableRowData: SelectionTableRowProps[];
 }
@@ -156,10 +145,6 @@ const buildStudentRepositoryPageConfiguration = ({
   students: UserRoleType[];
 }): RepositoriesTypePageConfiguration => {
   return {
-    title: 'Crear Repositorios (Individuales)',
-    description:
-      'Indicar la configuración de los repositorios a crear y seleccionar los alumnos a ' +
-      'quienes se les crearán sus repositorios en la organización del curso.',
     tableHeaders: ['Alumno', 'Padrón'],
     tableRowData: students
       .map(
@@ -196,108 +181,74 @@ const buildStudentRepositoryPageConfiguration = ({
 };
 
 const buildGroupRepositoryPageConfiguration = ({
-  groupUsersData,
-  courseAssignments,
+  groupUsersDataList,
 }: {
-  groupUsersData: GroupUsersData[];
-  courseAssignments: readonly AssignmentType[];
+  groupUsersDataList: GroupUsersData[];
 }): RepositoriesTypePageConfiguration => {
-  const tableRowData: GroupSelectionTableRowProps[] = groupUsersData
-    .reduce((result: GroupSelectionTableRowProps[], currentGroupUsersData) => {
-      const { group, usersByAssigment } = currentGroupUsersData;
+  const tableRowData: GroupSelectionTableRowProps[] = groupUsersDataList
+    .map(groupUsersData => {
+      const { groupId, groupName, users } = groupUsersData;
 
-      usersByAssigment.forEach(currentUsersByAssignment => {
-        const assignments = currentUsersByAssignment.assignmentIds
-          .map(assignmentId =>
-            courseAssignments.find(
-              courseAssignment => courseAssignment.id === assignmentId
-            )
-          )
-          .filter(assignment => assignment !== undefined) as AssignmentType[];
-        const users = currentUsersByAssignment.users;
-
-        /* Create stack to view better spaced */
-        const usersRowData = (
-          <Stack>
-            {users
-              .map((user): string => `${user.lastName}, ${user.name} (${user.file})`)
-              .sort((a: string, b: string) => a.localeCompare(b)) // Sort users alphabetically
-              .map((userData: string) => (
-                <Text>{userData}</Text>
-              ))}
-          </Stack>
-        );
-
-        /* Create stack to view better spaced */
-        const assignmentTitles = (
-          <Stack>
-            {assignments.map(assignment => (
-              <Text>{assignment.title}</Text>
+      /* Create stack to view better spaced */
+      const usersRowData = (
+        <Stack>
+          {users
+            .map((user): string => `${user.lastName}, ${user.name} (${user.file})`)
+            .sort((a: string, b: string) => a.localeCompare(b)) // Sort users alphabetically
+            .map((userData: string) => (
+              <Text>{userData}</Text>
             ))}
-          </Stack>
-        );
-        const groupName = group.name || '';
-        const groupId = group.id;
+        </Stack>
+      );
 
-        result.push({
-          groupId: groupId,
-          groupName: groupName,
-          assignments: assignments.map(assignment => ({
-            id: assignment.id || '',
-            title: assignment.title || '',
-          })),
-          participants: users.map(user => ({
-            userId: user.id,
-            name: user.name,
-            lastName: user.lastName,
-            file: user.file,
-          })),
-          rowData: [groupName, assignmentTitles, usersRowData],
-          checked: true,
-          id: `${groupId}-${assignments.map(a => a.id).join('-')}`,
-          getStudentIds: () => users.map(user => user.id),
-          getRepoName: (repositoryData: RepositoriesNameConfiguration) => {
-            const { prefix, useLastName, useFile, useGroupName } = repositoryData;
+      return {
+        groupId: groupId,
+        groupName: groupName,
+        participants: users.map(user => ({
+          userId: user.id,
+          name: user.name,
+          lastName: user.lastName,
+          file: user.file,
+        })),
+        rowData: [groupName, usersRowData],
+        checked: true,
+        id: groupId,
+        getStudentIds: () => users.map(user => user.id),
+        getRepoName: (repositoryData: RepositoriesNameConfiguration) => {
+          const { prefix, useLastName, useFile, useGroupName } = repositoryData;
 
-            const lastNames = useLastName
-              ? users.map(user => user.lastName).join('_')
-              : null;
-            const files = useFile ? users.map(user => user.file).join('_') : null;
-            const repoName = [
-              prefix || null,
-              useGroupName ? groupName : null,
-              lastNames,
-              files,
-            ]
-              .filter(item => item !== null)
-              .join('_')
-              .toLowerCase();
+          const lastNames = useLastName
+            ? users.map(user => user.lastName).join('_')
+            : null;
+          const files = useFile ? users.map(user => user.file).join('_') : null;
+          const repoName = [
+            prefix || null,
+            useGroupName ? groupName : null,
+            lastNames,
+            files,
+          ]
+            .filter(item => item !== null)
+            .join('_')
+            .toLowerCase();
 
-            return removeAccentsAndSpecialCharacters(repoName);
-          },
-        });
-      });
-
-      return result;
-    }, [])
+          return removeAccentsAndSpecialCharacters(repoName);
+        },
+      };
+    })
     .sort((a: GroupSelectionTableRowProps, b: GroupSelectionTableRowProps) =>
       a.groupName.localeCompare(b.groupName)
     ); // Sort by group names
 
   return {
-    title: 'Crear Repositorios (Grupales)',
-    description:
-      'Indicar la configuración de los repositorios a crear y seleccionar los grupos a ' +
-      'quienes se les crearán sus repositorios en la organización del curso.\n\n' +
-      'En caso de que un grupo tenga distintos integrantes en distintos trabajos prácticos se podrá ' +
-      'seleccionar a quienes crear el repositorio.',
-    tableHeaders: ['Grupo', 'Trabajo/s Práctico/s', 'Alumnos'],
+    tableHeaders: ['Grupo', 'Alumnos'],
     tableRowData,
   };
 };
 
 const CreateRepositoryPage = ({ type }: { type: RepositoryType }) => {
   const { courseId } = useUserContext();
+  const { assignmentId } = useParams();
+
   const navigate = useNavigate();
   const toast = useToast();
   const {
@@ -316,6 +267,7 @@ const CreateRepositoryPage = ({ type }: { type: RepositoryType }) => {
     CourseCreateRepositoryQueryDef,
     {
       courseId: courseId || '',
+      assignmentId: assignmentId || '',
     }
   );
 
@@ -325,12 +277,7 @@ const CreateRepositoryPage = ({ type }: { type: RepositoryType }) => {
 
   const course = courseQueryData.viewer?.course;
   const courseOrganization = course?.organization;
-  const courseAssignments = course?.assignments || [];
-  const groupUsersData: GroupUsersData[] =
-    course?.groups?.map(group => ({
-      group,
-      usersByAssigment: group.usersByAssignments,
-    })) || [];
+  const selectedAssignment = course?.assignments[0]; // Expect only one assignment
 
   const students = filterUsers({
     users: course?.userRoles || [],
@@ -354,12 +301,25 @@ const CreateRepositoryPage = ({ type }: { type: RepositoryType }) => {
 
   const [selectedRoles, setSelectedRoles] = useState<SelectedRoles>(getInitialRoles());
 
+  const groupDataById = new Map<string, GroupUsersData>();
+  selectedAssignment?.groupParticipants?.forEach(participant => {
+    const groupId = participant.group?.id;
+    const groupData = groupDataById.get(groupId);
+    if (!groupData) {
+      groupDataById.set(groupId, {
+        groupId: groupId,
+        groupName: participant.group.name || '-',
+        users: [],
+      });
+    }
+    groupDataById.get(groupId)?.users.push(participant.user);
+  });
+
   const getPageConfiguration = (): RepositoriesTypePageConfiguration => {
     return type === RepositoryType.Students
       ? buildStudentRepositoryPageConfiguration({ students })
       : buildGroupRepositoryPageConfiguration({
-          groupUsersData,
-          courseAssignments,
+          groupUsersDataList: Array.from(groupDataById.values()),
         });
   };
 
@@ -538,19 +498,23 @@ const CreateRepositoryPage = ({ type }: { type: RepositoryType }) => {
 
   return (
     <PageDataContainer>
-      <Heading>{pageConfiguration.title}</Heading>{' '}
-      <Flex justifyContent={'space-between'}>
-        <Flex direction={'column'} gap={'30px'} width={'500px'} paddingY={'20px'}>
-          <Text whiteSpace="pre-wrap">{pageConfiguration.description}</Text>
+      <Heading>{`Crear Repositorios | ${selectedAssignment?.title}`}</Heading>{' '}
+      <Flex justifyContent={'space-between'} paddingY={'20px'}>
+        <Flex direction={'column'} gap={'30px'} width={'500px'}>
+          <Text whiteSpace="pre-wrap">
+            {'Indicar la configuración de los repositorios a crear y seleccionar a ' +
+              'quienes se les crearán sus repositorios en la organización del curso para ' +
+              'el trabajo práctico elegido.\n\n'}
+          </Text>
 
           <ButtonWithIcon
-            onClick={onOpenRepoNamesConfigurationModal}
+            onClick={onOpenTeachersModal}
             text={'Configurar rol de profesores'}
             icon={MortarBoardIcon}
           />
 
           <ButtonWithIcon
-            onClick={onOpenTeachersModal}
+            onClick={onOpenRepoNamesConfigurationModal}
             text={'Configurar nombre repositorios'}
             icon={IdBadgeIcon}
           />
@@ -660,6 +624,7 @@ const CreateRepositoryPage = ({ type }: { type: RepositoryType }) => {
           <FormControl label={'Datos a incluir'}>
             <CheckboxGroup>
               <Stack spacing={[1, 5]} direction={['column', 'row']}>
+                {/* todo: TH-192 add assignment name as option */}
                 {type === RepositoryType.Groups && (
                   <Checkbox
                     id={'useGroupName'}

--- a/src/pages/courses/CreateRepository.tsx
+++ b/src/pages/courses/CreateRepository.tsx
@@ -624,7 +624,6 @@ const CreateRepositoryPage = ({ type }: { type: RepositoryType }) => {
           <FormControl label={'Datos a incluir'}>
             <CheckboxGroup>
               <Stack spacing={[1, 5]} direction={['column', 'row']}>
-                {/* todo: TH-192 add assignment name as option */}
                 {type === RepositoryType.Groups && (
                   <Checkbox
                     id={'useGroupName'}

--- a/src/pages/courses/assignments/AssignmentDashboard.tsx
+++ b/src/pages/courses/assignments/AssignmentDashboard.tsx
@@ -135,6 +135,7 @@ function AssignmentDetails({ assignment }: { assignment: Assignment }) {
             disabled={!viewerCanSubmit}
           />
         )}
+        {/* todo: TH-192 add create repository button */}
       </List>
     </Card>
   );

--- a/src/pages/courses/assignments/AssignmentDashboard.tsx
+++ b/src/pages/courses/assignments/AssignmentDashboard.tsx
@@ -135,7 +135,15 @@ function AssignmentDetails({ assignment }: { assignment: Assignment }) {
             disabled={!viewerCanSubmit}
           />
         )}
-        {/* todo: TH-192 add create repository button */}
+        {courseContext.userHasPermission(Permission.CreateRepository) && (
+          <LinkListItem
+            listItemKey={'createRepository'}
+            iconColor={LIST_ITEM_ICON_COLOR}
+            external={false}
+            text={'Crear repositorios'}
+            link={`new-repo/${assignment.isGroup ? 'groups' : 'students'}`}
+          />
+        )}
       </List>
     </Card>
   );

--- a/src/pages/courses/assignments/index.tsx
+++ b/src/pages/courses/assignments/index.tsx
@@ -22,6 +22,7 @@ import SubmissionIcon from 'icons/SubmissionIcon';
 import CreateIcon from 'icons/CreateIcon';
 import { ButtonWithIcon } from 'components/ButtonWithIcon';
 import { buildAssignmentUrlFilter } from 'queries';
+import CreateRepositoryIcon from 'icons/CreateRepositoryIcon';
 
 const AssignmentsPage = () => {
   const navigate = useNavigate();
@@ -38,6 +39,13 @@ const AssignmentsPage = () => {
       `../submissions` +
       (assignmentId ? `?${buildAssignmentUrlFilter(assignmentId)}` : '')
     );
+  };
+
+  const buildCreateRepositoryLink = (
+    assignmentId: string,
+    isGroupAssignment: boolean
+  ) => {
+    return assignmentId + '/new-repo' + (isGroupAssignment ? '/groups' : '/students');
   };
 
   return (
@@ -73,21 +81,34 @@ const AssignmentsPage = () => {
               content: [
                 `${data.title}`,
                 data.endDate ? formatAsSimpleDateTime(data.endDate) : '-',
-                <Flex>
+                <Stack direction={'row'} alignItems={'center'} justifyContent={'center'}>
                   <Tooltip label={'Ver entregas'}>
                     <Link
                       as={RRLink}
                       to={buildSubmissionLink(data.id)}
-                      onClick={event => event.stopPropagation()} // Avoid row clic behaviour
+                      onClick={event => event.stopPropagation()} // Avoid row click behaviour
                     >
                       <IconButton
                         variant={'ghost'}
                         aria-label="pull-request-link"
-                        icon={<SubmissionIcon size="medium" />}
+                        icon={<SubmissionIcon />}
                       />
                     </Link>
                   </Tooltip>
-                </Flex>,
+                  <Tooltip label={'Crear repositorios'}>
+                    <Link
+                      as={RRLink}
+                      to={buildCreateRepositoryLink(data.id, !!data.isGroup)}
+                      onClick={event => event.stopPropagation()} // Avoid row click behaviour
+                    >
+                      <IconButton
+                        variant={'ghost'}
+                        aria-label="create-repo-link"
+                        icon={<CreateRepositoryIcon />}
+                      />
+                    </Link>
+                  </Tooltip>
+                </Stack>,
               ],
             };
           })}


### PR DESCRIPTION

https://github.com/teach-hub/frontoffice/assets/31221128/66f38aee-17a3-46e0-9f0d-dcbb2de2e19e

Como en realidad la necesidad era que los repositorios se creen en el contexto de un trabajo practico cambie a que:
- la ruta ahora esta bajo **assignment/:id**
- desde la logica se simplifica porque ya no se unen grupos si comparten o no los integrantes, directamente se filtrar la query por el tp elegido y en base a eso se busca. La unica logica ahora es agrupar por grupo, pero mas sencillo que todo lo de antes
- elimine el acceso desde el navegador, dado que ahora necesitas el contexto de un tp. Algo que estuve pensando mientras lo hacia, como nota aparte igual, es que en realidad el boton + puede a tener la funcion de acceso a las acciones principales (ver tp, entregas sin filtro, etc.) que no necesite ningun contexto mas alla de curso, porque muchas de las acciones que nos estan quedando depende de tp y va a ser complicado resolver eso me parece. Hacer esto tambien es una alternativa a tener que pelearnos con breadcrumbs (hasta ahi igual)
- lo que antes estaba al navegador ahora seria botones desde el listado de tps, y sobre el detalle de cada tp 
