### PR TITLE
TH-153 Manage groups as teacher

### DIFF
--- a/src/__generated__/AddParticipantsToGroupMutation.graphql.ts
+++ b/src/__generated__/AddParticipantsToGroupMutation.graphql.ts
@@ -1,0 +1,125 @@
+/**
+ * @generated SignedSource<<7de8603962b9bfc1ecf815598e5e1ef2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type AddParticipantsToGroupMutation$variables = {
+  assignmentId: string;
+  groupId: string;
+  participantUserRoleIds: ReadonlyArray<string>;
+};
+export type AddParticipantsToGroupMutation$data = {
+  readonly addParticipantsToGroup: ReadonlyArray<{
+    readonly assignmentId: string;
+    readonly id: string;
+  } | null>;
+};
+export type AddParticipantsToGroupMutation = {
+  response: AddParticipantsToGroupMutation$data;
+  variables: AddParticipantsToGroupMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "assignmentId"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "groupId"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "participantUserRoleIds"
+},
+v3 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "assignmentId",
+        "variableName": "assignmentId"
+      },
+      {
+        "kind": "Variable",
+        "name": "groupId",
+        "variableName": "groupId"
+      },
+      {
+        "kind": "Variable",
+        "name": "participantUserRoleIds",
+        "variableName": "participantUserRoleIds"
+      }
+    ],
+    "concreteType": "InternalGroupParticipantType",
+    "kind": "LinkedField",
+    "name": "addParticipantsToGroup",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "assignmentId",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AddParticipantsToGroupMutation",
+    "selections": (v3/*: any*/),
+    "type": "RootMutationType",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "AddParticipantsToGroupMutation",
+    "selections": (v3/*: any*/)
+  },
+  "params": {
+    "cacheID": "7c828edfbc6c90080c0a7af9a5847081",
+    "id": null,
+    "metadata": {},
+    "name": "AddParticipantsToGroupMutation",
+    "operationKind": "mutation",
+    "text": "mutation AddParticipantsToGroupMutation(\n  $groupId: ID!\n  $assignmentId: ID!\n  $participantUserRoleIds: [ID!]!\n) {\n  addParticipantsToGroup(groupId: $groupId, assignmentId: $assignmentId, participantUserRoleIds: $participantUserRoleIds) {\n    id\n    assignmentId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "a657966af51b1ad454f8728b3decf7f2";
+
+export default node;

--- a/src/__generated__/AssignmentGroupsAndUsersQuery.graphql.ts
+++ b/src/__generated__/AssignmentGroupsAndUsersQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d514a24d7a9b431c9fe74b53af225402>>
+ * @generated SignedSource<<96969f80d8cd742588e0b5712526fae8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -29,6 +29,7 @@ export type AssignmentGroupsAndUsersQuery$data = {
             readonly lastName: string;
             readonly name: string;
           };
+          readonly userRoleId: string;
         }>;
         readonly id: string;
         readonly isGroup: boolean | null;
@@ -249,6 +250,13 @@ v6 = [
                   {
                     "alias": null,
                     "args": null,
+                    "kind": "ScalarField",
+                    "name": "userRoleId",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
                     "concreteType": "UserType",
                     "kind": "LinkedField",
                     "name": "user",
@@ -298,16 +306,16 @@ return {
     "selections": (v6/*: any*/)
   },
   "params": {
-    "cacheID": "f194aa183e4a6e55c5c58fbabf7f132a",
+    "cacheID": "0cd86b51a2cbdb3c67b20bdc88dace1e",
     "id": null,
     "metadata": {},
     "name": "AssignmentGroupsAndUsersQuery",
     "operationKind": "query",
-    "text": "query AssignmentGroupsAndUsersQuery(\n  $courseId: ID!\n  $assignmentId: ID\n) {\n  viewer {\n    id\n    name\n    course(id: $courseId) {\n      id\n      organization\n      userRoles {\n        id\n        user {\n          id\n          name\n          lastName\n          file\n          notificationEmail\n        }\n        role {\n          id\n          name\n          permissions\n          isTeacher\n        }\n      }\n      assignments(assignmentId: $assignmentId) {\n        id\n        title\n        isGroup\n        groupParticipants {\n          id\n          group {\n            id\n            name\n          }\n          user {\n            id\n            name\n            lastName\n            file\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query AssignmentGroupsAndUsersQuery(\n  $courseId: ID!\n  $assignmentId: ID\n) {\n  viewer {\n    id\n    name\n    course(id: $courseId) {\n      id\n      organization\n      userRoles {\n        id\n        user {\n          id\n          name\n          lastName\n          file\n          notificationEmail\n        }\n        role {\n          id\n          name\n          permissions\n          isTeacher\n        }\n      }\n      assignments(assignmentId: $assignmentId) {\n        id\n        title\n        isGroup\n        groupParticipants {\n          id\n          group {\n            id\n            name\n          }\n          userRoleId\n          user {\n            id\n            name\n            lastName\n            file\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "609fd7173611f07e9739f6a5181d4caa";
+(node as any).hash = "b98fd904e1162ea1395c773aaa051132";
 
 export default node;

--- a/src/__generated__/CreateGroupWithParticipantsMutation.graphql.ts
+++ b/src/__generated__/CreateGroupWithParticipantsMutation.graphql.ts
@@ -1,0 +1,138 @@
+/**
+ * @generated SignedSource<<6e7cba58ad31c06e15735932865cad76>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type CreateGroupWithParticipantsMutation$variables = {
+  assignmentId: string;
+  courseId: string;
+  groupName: string;
+  participantUserRoleIds: ReadonlyArray<string>;
+};
+export type CreateGroupWithParticipantsMutation$data = {
+  readonly createGroupWithParticipants: ReadonlyArray<{
+    readonly assignmentId: string;
+    readonly id: string;
+  } | null>;
+};
+export type CreateGroupWithParticipantsMutation = {
+  response: CreateGroupWithParticipantsMutation$data;
+  variables: CreateGroupWithParticipantsMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "assignmentId"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "courseId"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "groupName"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "participantUserRoleIds"
+},
+v4 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "assignmentId",
+        "variableName": "assignmentId"
+      },
+      {
+        "kind": "Variable",
+        "name": "courseId",
+        "variableName": "courseId"
+      },
+      {
+        "kind": "Variable",
+        "name": "groupName",
+        "variableName": "groupName"
+      },
+      {
+        "kind": "Variable",
+        "name": "participantUserRoleIds",
+        "variableName": "participantUserRoleIds"
+      }
+    ],
+    "concreteType": "InternalGroupParticipantType",
+    "kind": "LinkedField",
+    "name": "createGroupWithParticipants",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "assignmentId",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "CreateGroupWithParticipantsMutation",
+    "selections": (v4/*: any*/),
+    "type": "RootMutationType",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v2/*: any*/),
+      (v1/*: any*/),
+      (v0/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "CreateGroupWithParticipantsMutation",
+    "selections": (v4/*: any*/)
+  },
+  "params": {
+    "cacheID": "ecac720079af563a7595328096bb8e2c",
+    "id": null,
+    "metadata": {},
+    "name": "CreateGroupWithParticipantsMutation",
+    "operationKind": "mutation",
+    "text": "mutation CreateGroupWithParticipantsMutation(\n  $groupName: String!\n  $courseId: ID!\n  $assignmentId: ID!\n  $participantUserRoleIds: [ID!]!\n) {\n  createGroupWithParticipants(groupName: $groupName, courseId: $courseId, assignmentId: $assignmentId, participantUserRoleIds: $participantUserRoleIds) {\n    id\n    assignmentId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "9625448a2faff1a5d46d4a5f207ca0de";
+
+export default node;

--- a/src/app/groups.tsx
+++ b/src/app/groups.tsx
@@ -15,9 +15,9 @@ export type GroupUsersData = {
   users: GroupUserType[];
 };
 
-type AssignmentGroupsData = {
+export type AssignmentGroupsData = {
   groupUsersData: GroupUsersData[];
-  studentsNamesWithoutGroup: string[];
+  studentsWithoutGroup: GroupUserType[];
 };
 
 /**
@@ -54,20 +54,20 @@ export const getFirstAssignmentGroupsUsersData = ({
     roleFilter: UserRoleFilter.Student,
   });
 
-  const studentsWithoutGroup = mapToUserNames(
-    studentRoles
-      .filter(role => !studentsWithGroupIds.includes(role.user.id))
-      .map(role => role.user)
-  );
+  const studentsWithoutGroup = studentRoles
+    .filter(role => !studentsWithGroupIds.includes(role.user.id))
+    .map(role => role.user);
 
   return {
     groupUsersData: groupsDataList,
-    studentsNamesWithoutGroup: studentsWithoutGroup,
+    studentsWithoutGroup: studentsWithoutGroup,
   };
 };
 
+export const mapToUserName = (user: GroupUserType): string => {
+  return `${user.lastName}, ${user.name} (${user.file})`;
+};
+
 export const mapToUserNames = (users: GroupUserType[]): string[] => {
-  return users
-    .map((user): string => `${user.lastName}, ${user.name} (${user.file})`)
-    .sort((a: string, b: string) => a.localeCompare(b)); // Sort users alphabetically
+  return users.map(mapToUserName).sort((a: string, b: string) => a.localeCompare(b)); // Sort users alphabetically
 };

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -3,6 +3,7 @@ import {
   Modal as ChakraModal,
   ModalBody,
   ModalContent,
+  ModalContentProps as ChakraModalContentProps,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
@@ -13,13 +14,20 @@ type Props = ChakraModalProps & {
   children?: JSX.Element;
   headerText: string;
   footerChildren?: JSX.Element;
+  contentProps?: ChakraModalContentProps;
 };
 
-export const Modal = ({ headerText, children, footerChildren, ...rest }: Props) => {
+export const Modal = ({
+  headerText,
+  children,
+  contentProps,
+  footerChildren,
+  ...rest
+}: Props) => {
   return (
     <ChakraModal {...rest}>
       <ModalOverlay />
-      <ModalContent>
+      <ModalContent {...contentProps}>
         <ModalHeader>{headerText}</ModalHeader>
         <ModalBody>{children}</ModalBody>
         {footerChildren ? <ModalFooter>{footerChildren}</ModalFooter> : <ModalFooter />}

--- a/src/graphql/AddParticipantsToGroupMutation.tsx
+++ b/src/graphql/AddParticipantsToGroupMutation.tsx
@@ -1,0 +1,18 @@
+import { graphql } from 'babel-plugin-relay/macro';
+
+export default graphql`
+  mutation AddParticipantsToGroupMutation(
+    $groupId: ID!
+    $assignmentId: ID!
+    $participantUserRoleIds: [ID!]!
+  ) {
+    addParticipantsToGroup(
+      groupId: $groupId
+      assignmentId: $assignmentId
+      participantUserRoleIds: $participantUserRoleIds
+    ) {
+      id
+      assignmentId
+    }
+  }
+`;

--- a/src/graphql/AssignmentGroupsAndUsersQuery.tsx
+++ b/src/graphql/AssignmentGroupsAndUsersQuery.tsx
@@ -34,6 +34,7 @@ export default graphql`
               id
               name
             }
+            userRoleId
             user {
               id
               name

--- a/src/graphql/CreateGroupWithParticipantsMutation.tsx
+++ b/src/graphql/CreateGroupWithParticipantsMutation.tsx
@@ -1,0 +1,20 @@
+import { graphql } from 'babel-plugin-relay/macro';
+
+export default graphql`
+  mutation CreateGroupWithParticipantsMutation(
+    $groupName: String!
+    $courseId: ID!
+    $assignmentId: ID!
+    $participantUserRoleIds: [ID!]!
+  ) {
+    createGroupWithParticipants(
+      groupName: $groupName
+      courseId: $courseId
+      assignmentId: $assignmentId
+      participantUserRoleIds: $participantUserRoleIds
+    ) {
+      id
+      assignmentId
+    }
+  }
+`;

--- a/src/icons/AddPersonIcon.tsx
+++ b/src/icons/AddPersonIcon.tsx
@@ -1,0 +1,7 @@
+import { IconProps, PersonAddIcon } from '@primer/octicons-react';
+
+type Props = IconProps;
+
+export default (props: Props) => {
+  return <PersonAddIcon {...props} />;
+};

--- a/src/pages/courses/CreateRepository.tsx
+++ b/src/pages/courses/CreateRepository.tsx
@@ -196,7 +196,7 @@ const buildGroupRepositoryPageConfiguration = ({
       return {
         groupId: groupId,
         groupName: groupName,
-        participants: users.map(user => ({
+        participants: users.map(({ user }) => ({
           userId: user.id,
           name: user.name,
           lastName: user.lastName,
@@ -205,14 +205,14 @@ const buildGroupRepositoryPageConfiguration = ({
         rowData: [groupName, usersRowData],
         checked: true,
         id: groupId,
-        getStudentIds: () => users.map(user => user.id),
+        getStudentIds: () => users.map(({ user }) => user.id),
         getRepoName: (repositoryData: RepositoriesNameConfiguration) => {
           const { prefix, useLastName, useFile, useGroupName } = repositoryData;
 
           const lastNames = useLastName
-            ? users.map(user => user.lastName).join('_')
+            ? users.map(({ user }) => user.lastName).join('_')
             : null;
-          const files = useFile ? users.map(user => user.file).join('_') : null;
+          const files = useFile ? users.map(({ user }) => user.file).join('_') : null;
           const repoName = [
             prefix || null,
             useGroupName ? groupName : null,

--- a/src/pages/courses/assignments/groups/index.tsx
+++ b/src/pages/courses/assignments/groups/index.tsx
@@ -36,6 +36,11 @@ import {
   CreateGroupWithParticipantsMutation$data,
 } from '__generated__/CreateGroupWithParticipantsMutation.graphql';
 import CreateGroupWithParticipantsMutationDef from 'graphql/CreateGroupWithParticipantsMutation';
+import {
+  AddParticipantsToGroupMutation,
+  AddParticipantsToGroupMutation$data,
+} from '__generated__/AddParticipantsToGroupMutation.graphql';
+import AddParticipantsToGroupMutationDef from 'graphql/AddParticipantsToGroupMutation';
 import useToast from 'hooks/useToast';
 
 const GroupsPage = ({ courseContext }: { courseContext: FetchedContext }) => {
@@ -128,11 +133,35 @@ const GroupsPage = ({ courseContext }: { courseContext: FetchedContext }) => {
       CreateGroupWithParticipantsMutationDef
     );
 
+  const [commitAddParticipantsToGroup] = useMutation<AddParticipantsToGroupMutation>(
+    AddParticipantsToGroupMutationDef
+  );
+
   const handleAddUsersToGroup = () => {
-    /* TODO: TH-153 add mutation */
-    console.log(selectedGroupId);
-    console.log(selectedUserRoleIds);
-    onCloseAddUsersModal();
+    commitAddParticipantsToGroup({
+      variables: {
+        groupId: selectedGroupId || '',
+        assignmentId: assignmentId || '',
+        participantUserRoleIds: selectedUserRoleIds,
+      },
+      onCompleted: (response: AddParticipantsToGroupMutation$data, errors) => {
+        if (!errors?.length) {
+          toast({
+            title: 'Alumnos agregados!',
+            status: 'info',
+          });
+          onCloseAddUsersModal();
+          navigate(0); // Reload page data
+        } else {
+          console.log({ errors });
+          toast({
+            title: 'Error',
+            description: `Error al intentar unirse a grupo: ${errors?.at(0)?.message}`,
+            status: 'error',
+          });
+        }
+      },
+    });
   };
 
   const handleCreateGroup = (groupName: string) => {

--- a/src/pages/courses/assignments/groups/index.tsx
+++ b/src/pages/courses/assignments/groups/index.tsx
@@ -15,6 +15,10 @@ import { Stack } from '@chakra-ui/react';
 import Text from 'components/Text';
 import { theme } from 'theme';
 import { getFirstAssignmentGroupsUsersData, mapToUserNames } from 'app/groups';
+import IconButton from 'components/IconButton';
+import CreateIcon from 'icons/CreateIcon';
+import Tooltip from 'components/Tooltip';
+import AddPersonIcon from 'icons/AddPersonIcon';
 
 const GroupsPage = ({ courseContext }: { courseContext: FetchedContext }) => {
   const courseId = courseContext.courseId;
@@ -52,6 +56,19 @@ const GroupsPage = ({ courseContext }: { courseContext: FetchedContext }) => {
                   )
                 )}
               </Stack>,
+              <Stack direction={'row'} justifyContent={'center'} alignItems={'center'}>
+                <Tooltip label={'Crear nuevo grupo'}>
+                  {/* Wrap icon in span due to not using forwardRef */}
+                  <span>
+                    <IconButton
+                      variant={'ghost'}
+                      aria-label={'create-group'}
+                      icon={<CreateIcon size="medium" />}
+                      onClick={() => console.log('Create group')}
+                    />
+                  </span>
+                </Tooltip>
+              </Stack>,
             ],
           },
         ]
@@ -63,7 +80,7 @@ const GroupsPage = ({ courseContext }: { courseContext: FetchedContext }) => {
       <Stack paddingY={'10px'}>
         <Table
           tableHeight={'75vh'}
-          headers={['Grupo', 'Alumnos']}
+          headers={['Grupo', 'Alumnos', '']}
           rowOptions={assignmentGroupsData.groupUsersData
             .map(({ groupName, users }) => {
               {
@@ -77,7 +94,27 @@ const GroupsPage = ({ courseContext }: { courseContext: FetchedContext }) => {
                 );
 
                 return {
-                  content: [<Text>{groupName}</Text>, usersRowData],
+                  content: [
+                    <Text>{groupName}</Text>,
+                    usersRowData,
+                    <Stack
+                      direction={'row'}
+                      justifyContent={'center'}
+                      alignItems={'center'}
+                    >
+                      <Tooltip label={'Agregar alumnos'}>
+                        {/* Wrap icon in span due to not using forwardRef */}
+                        <span>
+                          <IconButton
+                            variant={'ghost'}
+                            aria-label={'add-users-to-group'}
+                            icon={<AddPersonIcon size="medium" />}
+                            onClick={() => console.log('Edit group')}
+                          />
+                        </span>
+                      </Tooltip>
+                    </Stack>,
+                  ],
                 };
               }
             })


### PR DESCRIPTION
Se agrega la gestion de grupos como profesor. Basicamente hay 2 posibles acciones que entiendo eran las necesarias:
- Crear un grupo para usuarios que no tienen, donde podes elegir todos los usuarios que queres sumar a ese grupo
- Agregar alumnos a un grupo que ya existe, donde tambien podes elegir los usuarios

Lo que esto no considera es editar grupos que ya existen o manejar alumno a alumno su grupo. Hay una tarea creada para verlo de ser necesario, pero no me parece una funcionalidad muy relavante frente a otros pendientes, quedara discutirlo en todo caso

https://github.com/teach-hub/frontoffice/assets/31221128/c69775be-fd87-4060-ad62-2d846196f8cd

