### PR TITLE
TH-188 Sort submissions table by name, add status filter and fix columns width

### DIFF
--- a/src/app/submissions.tsx
+++ b/src/app/submissions.tsx
@@ -9,7 +9,6 @@ export enum SubmissionStatus {
   NonExistent = 'Sin entregar',
   MissingReview = 'Sin corregir',
   NewSubmissionRequested = 'Reentrega solicitada',
-  InReview = 'En corrección',
   Reviewed = 'Corregido',
 }
 
@@ -37,16 +36,47 @@ const WarningBadgeConfiguration: BadgeConfiguration = {
   badgeTextColor: 'teachHub.black',
 };
 
-export const getSubmissionMissingStatusConfiguration = () => {
+const getSubmissionMissingStatusConfiguration = () => {
   return {
     text: SubmissionStatus.NonExistent,
     ...NonExistentBadgeConfiguration,
   };
 };
 
+type SubmissionsReviewStatusParams = {
+  grade: Optional<Nullable<number>>;
+  revisionRequested: Optional<Nullable<boolean>>;
+  missingSubmission: boolean;
+};
+
+export const getSubmissionsReviewStatusLabel = ({
+                                                  submission,
+                                                  review,
+                                                  missingSubmission,
+                                                }: {
+  submission: {
+    submittedAt: Optional<Nullable<string>>;
+    submittedAgainAt: Optional<Nullable<string>>;
+  };
+  review: {
+    reviewedAt: Optional<Nullable<string>>;
+    reviewedAgainAt: Optional<Nullable<string>>;
+    grade: Optional<Nullable<number>>;
+    revisionRequested: Optional<Nullable<boolean>>;
+  } | null;
+  missingSubmission: boolean;
+}): string => {
+  return getSubmissionReviewStatusConfiguration({
+    submissions,
+    review,
+    missingSubmission,
+  }).text;
+};
+
 export const getSubmissionReviewStatusConfiguration = ({
   submission,
-  review,
+  review, 
+  missingSubmission,
 }: {
   submission: {
     submittedAt: Optional<Nullable<string>>;
@@ -58,7 +88,10 @@ export const getSubmissionReviewStatusConfiguration = ({
     grade: Optional<Nullable<number>>;
     revisionRequested: Optional<Nullable<boolean>>;
   } | null;
+  missingSubmission: boolean;
 }): SubmissionReviewStatusConfiguration => {
+  if (missingSubmission) return getSubmissionMissingStatusConfiguration();
+  
   if (!review) {
     return {
       text: SubmissionStatus.MissingReview,

--- a/src/app/submissions.tsx
+++ b/src/app/submissions.tsx
@@ -9,6 +9,7 @@ export enum SubmissionStatus {
   NonExistent = 'Sin entregar',
   MissingReview = 'Sin corregir',
   NewSubmissionRequested = 'Reentrega solicitada',
+  NewSubmissionMissingReview = 'Reentrega sin corregir',
   Reviewed = 'Corregido',
 }
 
@@ -36,62 +37,42 @@ const WarningBadgeConfiguration: BadgeConfiguration = {
   badgeTextColor: 'teachHub.black',
 };
 
-const getSubmissionMissingStatusConfiguration = () => {
-  return {
-    text: SubmissionStatus.NonExistent,
-    ...NonExistentBadgeConfiguration,
-  };
-};
-
 type SubmissionsReviewStatusParams = {
-  grade: Optional<Nullable<number>>;
-  revisionRequested: Optional<Nullable<boolean>>;
-  missingSubmission: boolean;
-};
-
-export const getSubmissionsReviewStatusLabel = ({
-                                                  submission,
-                                                  review,
-                                                  missingSubmission,
-                                                }: {
-  submission: {
-    submittedAt: Optional<Nullable<string>>;
-    submittedAgainAt: Optional<Nullable<string>>;
-  };
+  submission:
+    | {
+        submittedAt: Optional<Nullable<string>>;
+        submittedAgainAt: Optional<Nullable<string>>;
+      }
+    | null
+    | undefined;
   review: {
     reviewedAt: Optional<Nullable<string>>;
     reviewedAgainAt: Optional<Nullable<string>>;
     grade: Optional<Nullable<number>>;
     revisionRequested: Optional<Nullable<boolean>>;
   } | null;
-  missingSubmission: boolean;
-}): string => {
+};
+
+export const getSubmissionsReviewStatusLabel = ({
+  submission,
+  review,
+}: SubmissionsReviewStatusParams): string => {
   return getSubmissionReviewStatusConfiguration({
-    submissions,
+    submission,
     review,
-    missingSubmission,
   }).text;
 };
 
 export const getSubmissionReviewStatusConfiguration = ({
   submission,
-  review, 
-  missingSubmission,
-}: {
-  submission: {
-    submittedAt: Optional<Nullable<string>>;
-    submittedAgainAt: Optional<Nullable<string>>;
-  };
-  review: {
-    reviewedAt: Optional<Nullable<string>>;
-    reviewedAgainAt: Optional<Nullable<string>>;
-    grade: Optional<Nullable<number>>;
-    revisionRequested: Optional<Nullable<boolean>>;
-  } | null;
-  missingSubmission: boolean;
-}): SubmissionReviewStatusConfiguration => {
-  if (missingSubmission) return getSubmissionMissingStatusConfiguration();
-  
+  review,
+}: SubmissionsReviewStatusParams): SubmissionReviewStatusConfiguration => {
+  if (!submission)
+    return {
+      text: SubmissionStatus.NonExistent,
+      ...NonExistentBadgeConfiguration,
+    };
+
   if (!review) {
     return {
       text: SubmissionStatus.MissingReview,
@@ -113,12 +94,12 @@ export const getSubmissionReviewStatusConfiguration = ({
     };
   } else if (review.reviewedAt && !review.reviewedAgainAt) {
     return {
-      text: 'Re-entrega sin corregir',
+      text: SubmissionStatus.NewSubmissionMissingReview,
       ...ErrorBadgeConfiguration,
     };
   } else {
     return {
-      text: 'Re-entrega corregida',
+      text: SubmissionStatus.Reviewed,
       ...SuccessBadgeConfiguration,
     };
   }

--- a/src/components/SubmissionsTable.tsx
+++ b/src/components/SubmissionsTable.tsx
@@ -18,6 +18,7 @@ import IconButton from 'components/IconButton';
 import Table from 'components/Table';
 
 import type { Nullable, Optional } from 'types';
+import { isAllEmpty } from 'utils/object';
 
 enum ColumnWidth {
   Student = '20%',
@@ -52,7 +53,7 @@ export type ReviewerRowData = SubjectRowData;
 export type SubmissionRowData = {
   id?: Optional<Nullable<string>>;
   grade: Optional<Nullable<number>>;
-  revisionRequested: Nullable<boolean>;
+  revisionRequested: Optional<Nullable<boolean>>;
   pullRequestUrl?: Optional<Nullable<string>>;
   submittedAt: Optional<Nullable<string>>;
   submittedAgainAt: Optional<Nullable<string>>;
@@ -120,10 +121,16 @@ export const SubmissionsTable = ({
       headers={columns.map(column => column.header)}
       headersWidths={columns.map(column => column.width)}
       rowOptions={rowDataList.map(rowData => {
+        const review = {
+          reviewedAt: rowData.submission?.reviewedAt,
+          reviewedAgainAt: rowData.submission?.reviewedAgainAt,
+          revisionRequested: rowData.submission?.revisionRequested,
+          grade: rowData.submission?.grade,
+        };
+
         const reviewStatusConfiguration = getSubmissionReviewStatusConfiguration({
           submission: rowData.submission,
-          review: rowData.submission,
-          missingSubmission: !rowData.submission?.id,
+          review: isAllEmpty(review) ? null : review,
         });
         const gradeConfiguration = getGradeConfiguration(rowData.submission?.grade);
 

--- a/src/components/SubmissionsTable.tsx
+++ b/src/components/SubmissionsTable.tsx
@@ -1,9 +1,7 @@
-import { ReactNode } from 'react';
 import { Stack } from '@chakra-ui/react';
 
 import {
   getGradeConfiguration,
-  getSubmissionMissingStatusConfiguration,
   getSubmissionReviewStatusConfiguration,
 } from 'app/submissions';
 import { getGithubRepoUrlFromPullRequestUrl } from 'utils/github';
@@ -21,10 +19,19 @@ import Table from 'components/Table';
 
 import type { Nullable, Optional } from 'types';
 
-type ExtraColumn = {
+enum ColumnWidth {
+  Student = '20%',
+  GroupName = '20%',
+  Assignment = '20%',
+  SubmissionStatus = '10%',
+  Reviewer = '20%',
+  Grade = '5%',
+  Actions = '5%',
+}
+
+type ColumnData = {
   header: string;
-  content: (rowData: RowData) => ReactNode;
-  columnIndex: number;
+  width: ColumnWidth;
 };
 
 export type SubjectRowData = {
@@ -62,54 +69,73 @@ export interface RowData {
 
 export const SubmissionsTable = ({
   rowDataList,
-  submitterNameHeader,
   onRowClick,
-  updateSelectedSubmitterCallback,
+  updateSelectedStudentCallback,
   updateSelectedReviewerCallback,
-  extraColumn,
+  groupParticipantsGetter,
 }: {
   rowDataList: RowData[];
-  submitterNameHeader: string;
   onRowClick: (rowData: RowData) => void;
-  updateSelectedSubmitterCallback?: (submitterId: Optional<Nullable<string>>) => void;
+  updateSelectedStudentCallback: (submitterId: Optional<Nullable<string>>) => void;
   updateSelectedReviewerCallback: (submitterId: Optional<Nullable<string>>) => void;
-  extraColumn?: ExtraColumn;
+  groupParticipantsGetter?: (rowData: RowData) => SubjectRowData[];
 }) => {
-  const baseHeaders = [
-    submitterNameHeader,
-    'Trabajo Práctico',
-    'Corrector',
-    'Estado',
-    'Nota',
-    '',
-  ];
-  const headers = extraColumn
-    ? [
-        ...baseHeaders.slice(0, extraColumn.columnIndex),
-        extraColumn.header,
-        ...baseHeaders.slice(extraColumn.columnIndex),
-      ]
-    : baseHeaders;
+  const isGroupTable = !!groupParticipantsGetter;
+
+  const columns: ColumnData[] = [
+    {
+      header: isGroupTable ? 'Grupo' : 'Alumno',
+      width: isGroupTable ? ColumnWidth.GroupName : ColumnWidth.Student,
+    },
+    isGroupTable
+      ? {
+          header: 'Alumnos',
+          width: ColumnWidth.Student,
+        }
+      : null,
+    {
+      header: 'Trabajo Práctico',
+      width: ColumnWidth.Assignment,
+    },
+    {
+      header: 'Corrector',
+      width: ColumnWidth.Reviewer,
+    },
+    {
+      header: 'Estado',
+      width: ColumnWidth.SubmissionStatus,
+    },
+    {
+      header: 'Nota',
+      width: ColumnWidth.Grade,
+    },
+    {
+      header: '',
+      width: ColumnWidth.Actions,
+    },
+  ].filter(Boolean) as ColumnData[];
+
   return (
     <Table
-      headers={headers}
+      headers={columns.map(column => column.header)}
+      headersWidths={columns.map(column => column.width)}
       rowOptions={rowDataList.map(rowData => {
-        // FIXME
-        const reviewStatusConfiguration = rowData.submission?.id
-          ? getSubmissionReviewStatusConfiguration({
-              submission: rowData.submission,
-              review: rowData.submission,
-            })
-          : getSubmissionMissingStatusConfiguration();
+        const reviewStatusConfiguration = getSubmissionReviewStatusConfiguration({
+          submission: rowData.submission,
+          review: rowData.submission,
+          missingSubmission: !rowData.submission?.id,
+        });
         const gradeConfiguration = getGradeConfiguration(rowData.submission?.grade);
 
-        const baseContent = [
-          /* If no callback set, show as simple string */
-          updateSelectedSubmitterCallback ? (
+        const pullRequestUrl = rowData.submission?.pullRequestUrl;
+
+        const content = [
+          /* If group table, show as simple string */
+          !isGroupTable ? (
             <Link // Link without redirect
               onClick={event => {
                 event.stopPropagation(); // This prevents the click from propagating to the parent row
-                updateSelectedSubmitterCallback(rowData.submitter.id);
+                updateSelectedStudentCallback(rowData.submitter.id);
               }}
             >
               {rowData.submitter.name}
@@ -117,6 +143,20 @@ export const SubmissionsTable = ({
           ) : (
             rowData.submitter.name
           ),
+          isGroupTable ? (
+            <Stack>
+              {groupParticipantsGetter(rowData).map(participant => (
+                <Link // Link without redirect
+                  onClick={event => {
+                    event.stopPropagation(); // This prevents the click from propagating to the parent row
+                    updateSelectedStudentCallback(participant.id);
+                  }}
+                >
+                  {participant.name}
+                </Link>
+              ))}
+            </Stack>
+          ) : null,
           rowData.assignmentTitle,
           <Link // Link without redirect
             onClick={event => {
@@ -131,46 +171,41 @@ export const SubmissionsTable = ({
             grade={rowData.submission?.grade}
             gradeConfiguration={gradeConfiguration}
           />,
-          rowData.submission?.pullRequestUrl && (
-            <Stack direction={'row'}>
-              <Tooltip label={'Ir a repositorio'}>
-                <Link
-                  href={getGithubRepoUrlFromPullRequestUrl(
-                    rowData.submission?.pullRequestUrl
-                  )}
-                  isExternal
-                  onClick={event => event.stopPropagation()} // Avoid row click behaviour
-                >
-                  <IconButton
-                    variant={'ghost'}
-                    aria-label="repository-link"
-                    icon={<RepositoryIcon />}
-                  />
-                </Link>
-              </Tooltip>
-              <Tooltip label={'Ir a pull request'}>
-                <Link
-                  href={rowData.submission?.pullRequestUrl}
-                  isExternal
-                  onClick={event => event.stopPropagation()} // Avoid row click behaviour
-                >
-                  <IconButton
-                    variant={'ghost'}
-                    aria-label="pull-request-link"
-                    icon={<PullRequestIcon />}
-                  />
-                </Link>
-              </Tooltip>
-            </Stack>
-          ),
-        ];
-        const content = extraColumn
-          ? [
-              ...baseContent.slice(0, extraColumn.columnIndex),
-              extraColumn.content(rowData),
-              ...baseContent.slice(extraColumn.columnIndex),
-            ]
-          : baseContent;
+          <Stack direction={'row'}>
+            <Tooltip label={'Ir a repositorio'}>
+              <Link
+                href={
+                  pullRequestUrl
+                    ? getGithubRepoUrlFromPullRequestUrl(pullRequestUrl)
+                    : undefined
+                }
+                isExternal
+                onClick={event => event.stopPropagation()} // Avoid row click behaviour
+              >
+                <IconButton
+                  variant={'ghost'}
+                  aria-label="repository-link"
+                  icon={<RepositoryIcon />}
+                  disabled={!rowData.submission?.pullRequestUrl}
+                />
+              </Link>
+            </Tooltip>
+            <Tooltip label={'Ir a pull request'}>
+              <Link
+                href={pullRequestUrl ? pullRequestUrl : undefined}
+                isExternal
+                onClick={event => event.stopPropagation()} // Avoid row click behaviour
+              >
+                <IconButton
+                  variant={'ghost'}
+                  aria-label="pull-request-link"
+                  icon={<PullRequestIcon />}
+                  disabled={!rowData.submission?.pullRequestUrl}
+                />
+              </Link>
+            </Tooltip>
+          </Stack>,
+        ].filter(Boolean);
 
         return {
           rowProps: {

--- a/src/pages/courses/assignments/submissions/submission.tsx
+++ b/src/pages/courses/assignments/submissions/submission.tsx
@@ -6,9 +6,9 @@ import { PayloadError } from 'relay-runtime';
 import {
   CheckCircleFillIcon,
   InfoIcon,
+  IterationsIcon,
   MortarBoardIcon,
   NumberIcon,
-  IterationsIcon,
   PencilIcon,
   PeopleIcon,
   PersonFillIcon,
@@ -67,6 +67,7 @@ import type { SubmissionQuery } from '__generated__/SubmissionQuery.graphql';
 
 const CarrouselNavigationControls = ({ submissionId }: { submissionId: string }) => {
   const { submissionIds } = useSubmissionContext();
+  console.log(submissionIds);
 
   const previousSubmissionId = getValueOfPreviousIndex(submissionIds, submissionId);
   const nextSubmissionId = getValueOfNextIndex(submissionIds, submissionId);
@@ -168,14 +169,13 @@ const SubmissionPage = ({
   const reviewStatusConfiguration = getSubmissionReviewStatusConfiguration({
     review,
     submission,
-    missingSubmission: false,
   });
   const gradeConfiguration = getGradeConfiguration(review?.grade);
 
   const reviewEnabled = submission?.viewerCanReview;
   const viewerCanSubmitAgain = review?.reviewedAt && review.revisionRequested;
 
-  const handleReviewButtonClick = () => {
+  const showWarningToastIfDisabled = () => {
     if (!reviewEnabled) {
       toast({
         title: 'No es posible calificar',
@@ -183,7 +183,6 @@ const SubmissionPage = ({
         status: 'warning',
       });
     }
-    onOpenReviewModal();
   };
 
   const handleSubmitButtonClick = () => {
@@ -319,12 +318,15 @@ const SubmissionPage = ({
       <Stack gap={'30px'} marginTop={'10px'}>
         <Flex direction={'row'} gap={'5px'}>
           {context.userHasPermission(Permission.SetReview) && (
-            <ButtonWithIcon
-              onClick={handleReviewButtonClick}
-              text={'Calificar'}
-              icon={PencilIcon}
-              isDisabled={!reviewEnabled}
-            />
+            /* Use div for toast to appear*/
+            <div onClick={showWarningToastIfDisabled}>
+              <ButtonWithIcon
+                onClick={onOpenReviewModal}
+                text={'Calificar'}
+                icon={PencilIcon}
+                isDisabled={!reviewEnabled}
+              />
+            </div>
           )}
           {context.userHasPermission(Permission.SubmitAssignment) && (
             <ButtonWithIcon

--- a/src/pages/courses/assignments/submissions/submission.tsx
+++ b/src/pages/courses/assignments/submissions/submission.tsx
@@ -10,8 +10,8 @@ import {
   NumberIcon,
   IterationsIcon,
   PencilIcon,
-  PersonFillIcon,
   PeopleIcon,
+  PersonFillIcon,
   XCircleFillIcon,
 } from '@primer/octicons-react';
 
@@ -168,6 +168,7 @@ const SubmissionPage = ({
   const reviewStatusConfiguration = getSubmissionReviewStatusConfiguration({
     review,
     submission,
+    missingSubmission: false,
   });
   const gradeConfiguration = getGradeConfiguration(review?.grade);
 

--- a/src/statistics/submissions.tsx
+++ b/src/statistics/submissions.tsx
@@ -2,9 +2,15 @@ import { Nullable, Optional } from 'types';
 import { SubmissionStatus } from 'app/submissions';
 import { theme } from 'theme';
 
-const getSubmissionStatus = (
+/*
+ * Handle separated status for statistics, that groups statuses
+ * that are in review
+ * */
+const SUBMISSION_IN_REVIEW_LABEL = 'En corrección';
+
+const getSubmissionStatusLabel = (
   submissionStatisticsData: SubmissionStatisticsData
-): SubmissionStatus => {
+): string => {
   const { grade, revisionRequested } = submissionStatisticsData;
   const hasGrade = !!grade;
   const missingReview = !hasGrade && !revisionRequested;
@@ -13,7 +19,7 @@ const getSubmissionStatus = (
   } else if (hasGrade) {
     return SubmissionStatus.Reviewed;
   } else {
-    return SubmissionStatus.InReview;
+    return SUBMISSION_IN_REVIEW_LABEL;
   }
 };
 
@@ -33,7 +39,7 @@ export const getAssignmentSubmissionStatusDataset = (
 ) => {
   const assignmentsStatusList = assignmentSubmissionsStatisticsData.map(item => {
     return item.submissions
-      .map(getSubmissionStatus)
+      .map(getSubmissionStatusLabel)
       .concat(
         Array(item.nonExistentSubmissionsAmount).fill(SubmissionStatus.NonExistent)
       );
@@ -45,7 +51,7 @@ export const getAssignmentSubmissionStatusDataset = (
       backgroundColor: `${theme.colors.teachHub.green}`,
     },
     {
-      status: SubmissionStatus.InReview,
+      status: SUBMISSION_IN_REVIEW_LABEL,
       backgroundColor: `${theme.colors.teachHub.yellow}`,
     },
     {

--- a/src/utils/object.tsx
+++ b/src/utils/object.tsx
@@ -1,0 +1,2 @@
+export const isAllEmpty = (object: object): boolean =>
+  Object.values(object).every(x => x === null || x === undefined || x === '');


### PR DESCRIPTION
Probando distintas alterantivas lo que me parecio mas util termino siendo:
- ordenar por defecto las 2 tablas por el nombre, sea de alumno o grupo segun cada una
- agregar un filtro por estado

Entre que ya tenemos la opcion de filtrar por alumno, corrector, tp y estado, alterar el ordenamiento me parecio dejaba de tener sentido, y agregaba complejidad sin mucho sentido

https://github.com/teach-hub/frontoffice/assets/31221128/025963b2-3738-4adf-a2be-63bb44ad2dd6


Ademas de eso, otro cambio que meti es fijar el ancho de las columnas, porque probando los filtros pasaba que la tabla cambiaba todo el tiempo de tamaño y se veia bastante mal. Era un mecanismo que ya habia armado para otro pr y pase  dejarlo configurado tambien aca.

Y ultimo cambio, active siempre los botones de pr y repo de github, nada mas que si no tiene los datos mostrarlos desactivados, asi seguimos el mismo comportamiento que otras tablas y la tabla se veia mas similar fila a fila


