### PR TITLE
TH-213 Refactor assignment dashboard

### DIFF
--- a/src/components/BoxWithTopAndBottomBorders.tsx
+++ b/src/components/BoxWithTopAndBottomBorders.tsx
@@ -1,0 +1,18 @@
+import { Box as ChakraBox, BoxProps } from '@chakra-ui/react';
+import { theme } from 'theme';
+
+type Props = BoxProps;
+
+const Box = (props: Props) => {
+  return (
+    <ChakraBox
+      {...props}
+      borderColor={theme.colors.teachHub.gray}
+      borderWidth={1} // Put borders only on top and bottom
+      borderLeftWidth={0}
+      borderRightWidth={0}
+      padding={5}
+    />
+  );
+};
+export default Box;

--- a/src/components/RRLink.tsx
+++ b/src/components/RRLink.tsx
@@ -1,0 +1,17 @@
+import { Link as ChakraLink } from '@chakra-ui/react';
+import { Link as RRLink, LinkProps as RRLinkProps } from 'react-router-dom';
+
+type Props = RRLinkProps & {
+  disabled?: boolean;
+};
+
+const Link = (props: Props) => {
+  return (
+    <ChakraLink
+      as={RRLink}
+      {...props}
+      style={{ pointerEvents: props.disabled ? 'none' : undefined }}
+    />
+  );
+};
+export default Link;

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -6,7 +6,8 @@ type Props = TooltipProps;
 const Tooltip = (props: Props) => {
   return (
     <ChakraTooltip hasArrow fontSize={theme.styles.global.body.fontSize} {...props}>
-      {props.children}
+      {/* Wrap children in span in case of it not using forwardRef */}
+      <span>{props.children}</span>
     </ChakraTooltip>
   );
 };

--- a/src/icons/ReviewerIcon.tsx
+++ b/src/icons/ReviewerIcon.tsx
@@ -1,0 +1,7 @@
+import { IconProps, MortarBoardIcon } from '@primer/octicons-react';
+
+type Props = IconProps;
+
+export default (props: Props) => {
+  return <MortarBoardIcon size="medium" {...props} />;
+};

--- a/src/pages/courses/assignments/create.tsx
+++ b/src/pages/courses/assignments/create.tsx
@@ -59,7 +59,7 @@ const CreateAssignmentPage = ({ courseId }: Props) => {
         if (!errors?.length && data) {
           toast({
             title: 'Trabajo práctico guardado!',
-            status: 'info',
+            status: 'success',
           });
           navigate(`../${data.id}`);
         } else {

--- a/src/pages/courses/assignments/groups/index.tsx
+++ b/src/pages/courses/assignments/groups/index.tsx
@@ -89,17 +89,14 @@ const GroupsPage = ({ courseContext }: { courseContext: FetchedContext }) => {
             </Stack>,
             <Stack direction={'row'} justifyContent={'center'} alignItems={'center'}>
               <Tooltip label={'Crear nuevo grupo'}>
-                {/* Wrap icon in span due to not using forwardRef */}
-                <span>
-                  <IconButton
-                    variant={'ghost'}
-                    aria-label={'create-group'}
-                    icon={<CreateIcon size="medium" />}
-                    onClick={() => {
-                      onOpenCreateGroupModal();
-                    }}
-                  />
-                </span>
+                <IconButton
+                  variant={'ghost'}
+                  aria-label={'create-group'}
+                  icon={<CreateIcon size="medium" />}
+                  onClick={() => {
+                    onOpenCreateGroupModal();
+                  }}
+                />
               </Tooltip>
             </Stack>,
           ],
@@ -213,18 +210,15 @@ const GroupsPage = ({ courseContext }: { courseContext: FetchedContext }) => {
                       alignItems={'center'}
                     >
                       <Tooltip label={'Agregar alumnos'}>
-                        {/* Wrap icon in span due to not using forwardRef */}
-                        <span>
-                          <IconButton
-                            variant={'ghost'}
-                            aria-label={'add-users-to-group'}
-                            icon={<AddPersonIcon size="medium" />}
-                            onClick={() => {
-                              setSelectedGroupId(groupId);
-                              onOpenAddUsersModal();
-                            }}
-                          />
-                        </span>
+                        <IconButton
+                          variant={'ghost'}
+                          aria-label={'add-users-to-group'}
+                          icon={<AddPersonIcon size="medium" />}
+                          onClick={() => {
+                            setSelectedGroupId(groupId);
+                            onOpenAddUsersModal();
+                          }}
+                        />
                       </Tooltip>
                     </Stack>,
                   ],

--- a/src/pages/courses/assignments/index.tsx
+++ b/src/pages/courses/assignments/index.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-import { Link as RRLink, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useLazyLoadQuery } from 'react-relay';
 
 import CourseAssignmentsQueryDef from 'graphql/CourseAssignmentsQuery';
@@ -16,7 +16,6 @@ import type { CourseAssignmentsQuery } from '__generated__/CourseAssignmentsQuer
 import { Flex, Stack } from '@chakra-ui/react';
 import Table, { ClickableRowPropsConfiguration } from 'components/Table';
 import Tooltip from 'components/Tooltip';
-import Link from 'components/Link';
 import IconButton from 'components/IconButton';
 import SubmissionIcon from 'icons/SubmissionIcon';
 import CreateIcon from 'icons/CreateIcon';
@@ -25,6 +24,7 @@ import { buildAssignmentUrlFilter } from 'queries';
 import CreateRepositoryIcon from 'icons/CreateRepositoryIcon';
 import GroupIcon from 'icons/GroupIcon';
 import useToast from 'hooks/useToast';
+import RRLink from 'components/RRLink';
 
 const AssignmentsPage = () => {
   const toast = useToast();
@@ -109,8 +109,7 @@ const AssignmentsPage = () => {
                   {courseContext.userHasPermission(Permission.ViewGroups) &&
                     data.isGroup && (
                       <Tooltip label={'Ver grupos'}>
-                        <Link
-                          as={RRLink}
+                        <RRLink
                           to={buildAssignmentGroupsLink(data.id)}
                           onClick={event => event.stopPropagation()} // Avoid row click behaviour
                         >
@@ -119,17 +118,17 @@ const AssignmentsPage = () => {
                             aria-label="view-groups"
                             icon={<GroupIcon />}
                           />
-                        </Link>
+                        </RRLink>
                       </Tooltip>
                     )}
                   <Tooltip label={isTeacher ? 'Ver entregas' : 'Ver entrega'}>
-                    <Link
-                      as={RRLink}
+                    <RRLink
                       to={buildSubmissionLink({
                         assignmentId: data.id,
                         viewerSubmissionId: data.viewerSubmission?.id,
                       })}
                       onClick={event => event.stopPropagation()} // Avoid row click behaviour
+                      disabled={isStudentAndMissingSubmissions}
                     >
                       <IconButton
                         variant={'ghost'}
@@ -146,12 +145,11 @@ const AssignmentsPage = () => {
                             });
                         }}
                       />
-                    </Link>
+                    </RRLink>
                   </Tooltip>
                   {courseContext.userHasPermission(Permission.CreateRepository) && (
                     <Tooltip label={'Crear repositorios'}>
-                      <Link
-                        as={RRLink}
+                      <RRLink
                         to={buildCreateRepositoryLink(data.id, !!data.isGroup)}
                         onClick={event => event.stopPropagation()} // Avoid row click behaviour
                       >
@@ -160,7 +158,7 @@ const AssignmentsPage = () => {
                           aria-label="create-repo-link"
                           icon={<CreateRepositoryIcon />}
                         />
-                      </Link>
+                      </RRLink>
                     </Tooltip>
                   )}
                 </Stack>,

--- a/src/pages/courses/assignments/submissions/submission.tsx
+++ b/src/pages/courses/assignments/submissions/submission.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useEffect, useState } from 'react';
-import { Link as RRLink, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useLazyLoadQuery, useMutation } from 'react-relay';
 import { PayloadError } from 'relay-runtime';
 
@@ -70,6 +70,7 @@ import type {
 import Divider from 'components/Divider';
 import CommentIcon from 'icons/CommentIcon';
 import MarkdownText from 'components/MarkdownText';
+import RRLink from 'components/RRLink';
 
 type CommentType = NonNullable<
   NonNullable<
@@ -90,24 +91,24 @@ const CarrouselNavigationControls = ({ submissionId }: { submissionId: string })
     <Stack direction={'row'} gap={'5px'}>
       {previousSubmissionUrl && (
         <Tooltip label={'Ver entrega anterior'}>
-          <Link as={RRLink} to={previousSubmissionUrl}>
+          <RRLink to={previousSubmissionUrl}>
             <IconButton
               variant={'ghost'}
               aria-label="previous-submission"
               icon={<BackArrowIcon />}
             />
-          </Link>
+          </RRLink>
         </Tooltip>
       )}
       {nextSubmissionUrl && (
         <Tooltip label={'Ver siguiente entrega'}>
-          <Link as={RRLink} to={nextSubmissionUrl}>
+          <RRLink to={nextSubmissionUrl}>
             <IconButton
               variant={'ghost'}
               aria-label="next-submission"
               icon={<NextArrowIcon />}
             />
-          </Link>
+          </RRLink>
         </Tooltip>
       )}
     </Stack>
@@ -304,9 +305,9 @@ const SubmissionPage = ({
         <Flex direction="row" gap={'20px'} align={'center'}>
           <Heading>
             Entrega | {headingText} |{' '}
-            <Link as={RRLink} to={VIEW_ASSIGNMENT_LINK} color={'teachHub.primaryLight'}>
+            <RRLink to={VIEW_ASSIGNMENT_LINK} color={'teachHub.primaryLight'}>
               {assignment.title}
-            </Link>
+            </RRLink>
           </Heading>
           <Stack direction={'row'}>
             <Tooltip label={'Ir a repositorio'}>

--- a/src/pages/courses/assignments/update.tsx
+++ b/src/pages/courses/assignments/update.tsx
@@ -13,9 +13,8 @@ import Navigation from 'components/Navigation';
 import Heading from 'components/Heading';
 import PageDataContainer from 'components/PageDataContainer';
 
-import AssignmentForm from 'layout/AssignmentForm';
-
 import type { InitialValues } from 'layout/AssignmentForm';
+import AssignmentForm from 'layout/AssignmentForm';
 import type { FormErrors } from 'types';
 
 import type {
@@ -87,7 +86,7 @@ const UpdateAssignmentPage = ({ assignmentId, courseId }: UpdatePageProps) => {
         if (!errors?.length && data) {
           toast({
             title: 'Trabajo práctico guardado!',
-            status: 'info',
+            status: 'success',
           });
           navigate(`..`);
         } else {

--- a/src/pages/courses/course.tsx
+++ b/src/pages/courses/course.tsx
@@ -68,6 +68,7 @@ import { Modal } from 'components/Modal';
 import Navigation from 'components/Navigation';
 import { theme } from 'theme';
 import Spinner from 'components/Spinner';
+import BoxWithTopAndBottomBorders from 'components/BoxWithTopAndBottomBorders';
 
 type CourseType = NonNullable<NonNullable<CourseInfoQuery$data['viewer']>['course']>;
 
@@ -330,18 +331,13 @@ const CourseViewContainer = () => {
       </Stack>
       <Stack gap={'30px'}>
         {description && (
-          <Box
+          <BoxWithTopAndBottomBorders
             maxHeight={'30vh'}
             overflow={'auto'}
             maxWidth={'100%'}
-            borderColor={theme.colors.teachHub.gray}
-            borderWidth={1} // Put borders only on top and bottom
-            borderLeftWidth={0}
-            borderRightWidth={0}
-            padding={5}
           >
             <MarkdownText markdown={description} />
-          </Box>
+          </BoxWithTopAndBottomBorders>
         )}
         <CourseStatistics
           courseContext={courseContext}


### PR DESCRIPTION
Resumen de cambios:
- Se descarta la card, para seguir formato similar a, por ejemplo, pantalla de detalle de entrega
- Separe lo que seria la informacion del tp de lo que serian acciones sobre el tp
- Las acciones se mueven para arriba, debajo del titulo, la informacion del tp queda por debajo de la descripcion
- Del lado de alumno elimine el item de **estado de entrega**, porque repetia lo que quieren mostrar los botones de accion de ese lado

Dejo capturas de como queda de cada lado la info

Como profesor:
![image](https://github.com/teach-hub/frontoffice/assets/31221128/88a71807-626d-44ae-9fbe-d72bcf7d80bc)

Como alumno:
![image](https://github.com/teach-hub/frontoffice/assets/31221128/2e00719a-e297-48ef-b3e7-39479d0a8af1)
