### PR TITLE
[TH-162] Agrega secciones principales al navegador

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,15 @@ import {
   useLocation,
 } from 'react-router-dom';
 import { ChakraProvider } from '@chakra-ui/react';
+import {
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  Title,
+  Tooltip,
+} from 'chart.js';
 
 import environment from 'relayEnvironment';
 
@@ -29,23 +38,17 @@ import SubmissionPage from 'pages/courses/assignments/submissions/submission';
 import GroupsPage from 'pages/courses/assignments/groups/index';
 import AddSubmissionPage from 'pages/courses/assignments/submissions/add';
 import AssignReviewersPage from 'pages/courses/assignments/reviewers';
+import MyGroups from 'pages/courses/groups/MyGroups';
 
 import { ContextProvider } from 'hooks/useUserCourseContext';
 import { storeGetValue } from 'hooks/useLocalStorage';
+import { SubmissionProvider } from 'hooks/useSubmissionsContext';
+
+import { buildLoginRoute } from 'routes';
+
 import { isAuthenticated } from 'auth/utils';
 
 import { theme } from 'theme';
-import MyGroups from 'pages/courses/groups/MyGroups';
-import { SubmissionProvider } from 'hooks/useSubmissionsContext';
-import {
-  BarElement,
-  CategoryScale,
-  Chart as ChartJS,
-  Legend,
-  LinearScale,
-  Title,
-  Tooltip,
-} from 'chart.js';
 
 /*
  * Way to solve protected routes, as routes can not
@@ -61,7 +64,7 @@ const ProtectedLayout = ({ children }: { children: JSX.Element }): JSX.Element =
 
   console.log(`User not authenticated, redirecting to /login`);
 
-  return <Navigate to="/login" state={{ redirectTo: location.pathname }} />;
+  return <Navigate to={buildLoginRoute()} state={{ redirectTo: location.pathname }} />;
 };
 
 const App = () => {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,9 +1,9 @@
 import { ReactNode, Suspense, useState } from 'react';
-import { Link as ReachLink, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { graphql } from 'babel-plugin-relay/macro';
 import { useLazyLoadQuery, useMutation } from 'react-relay';
-import { HStack, Link, Skeleton, SkeletonCircle } from '@chakra-ui/react';
+import { HStack, Skeleton, SkeletonCircle } from '@chakra-ui/react';
 import { AddIcon, ChevronDownIcon } from '@chakra-ui/icons';
 
 import Box from 'components/Box';
@@ -12,8 +12,10 @@ import Avatar from 'components/Avatar';
 import Menu, { Props as MenuProps } from 'components/Menu';
 import Divider from 'components/Divider';
 import HomeButton from 'components/HomeButton';
+import Routes from 'components/Routes';
 
 import { theme } from 'theme';
+import { buildMyGroupsRoute, buildAddSubmissionRoute } from 'routes';
 
 import { storeGetValue, storeRemoveValue } from 'hooks/useLocalStorage';
 import { Permission, useUserContext } from 'hooks/useUserCourseContext';
@@ -28,16 +30,6 @@ import {
   LogoutMutation$data,
 } from '__generated__/LogoutMutation.graphql';
 import { NavigationQuery } from '__generated__/NavigationQuery.graphql';
-
-const MainRoutes = () => {
-  return (
-    <HStack spacing="30px">
-      <Link as={ReachLink} to="/courses">
-        Cursos
-      </Link>
-    </HStack>
-  );
-};
 
 const NAVIGATION_HEIGHT_PX = 95;
 
@@ -65,6 +57,10 @@ const NavigationBar = () => {
   );
 
   if (!viewerData?.viewer?.id) {
+    return null;
+  }
+
+  if (!courseContext.courseId) {
     return null;
   }
 
@@ -108,18 +104,14 @@ const NavigationBar = () => {
   if (courseContext.userHasPermission(Permission.SubmitAssignment)) {
     studentActions.push({
       content: 'Realizar nueva entrega',
-      action: () => {
-        navigate(`/courses/${courseContext.courseId}/add-submission`);
-      },
+      action: () => navigate(buildAddSubmissionRoute(courseContext.courseId)),
     });
   }
 
   if (courseContext.userHasPermission(Permission.ManageOwnGroups)) {
     studentActions.push({
       content: 'Gestionar mis grupos',
-      action: () => {
-        navigate(`/courses/${courseContext.courseId}/my-groups`);
-      },
+      action: () => navigate(buildMyGroupsRoute(courseContext.courseId)),
     });
   }
 
@@ -143,7 +135,7 @@ const NavigationBar = () => {
       <Divider h="75%" />
 
       <HStack flex="1" spacing="auto">
-        <MainRoutes />
+        <Routes />
         <Menu
           content={{
             menuButton: (
@@ -178,14 +170,12 @@ const NavigationBar = () => {
         }}
       />
 
-      {courseContext.courseId && (
-        <InviteUserModal
-          isOpen={inviteUserOpen}
-          rootQueryRef={viewerData}
-          onClose={() => setInviteUserOpen(false)}
-          courseId={courseContext.courseId}
-        />
-      )}
+      <InviteUserModal
+        isOpen={inviteUserOpen}
+        rootQueryRef={viewerData}
+        onClose={() => setInviteUserOpen(false)}
+        courseId={courseContext.courseId}
+      />
     </HStack>
   );
 };

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -107,16 +107,6 @@ const NavigationBar = () => {
     });
   }
 
-  if (
-    courseContext.courseId &&
-    courseContext.userHasPermission(Permission.ManageOwnGroups)
-  ) {
-    studentActions.push({
-      content: 'Gestionar mis grupos',
-      action: () => navigate(buildMyGroupsRoute(courseContext.courseId)),
-    });
-  }
-
   return (
     <HStack
       spacing="25px"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -60,10 +60,6 @@ const NavigationBar = () => {
     return null;
   }
 
-  if (!courseContext.courseId) {
-    return null;
-  }
-
   const handleLogout = () => {
     const currentToken = storeGetValue('token');
     currentToken &&
@@ -101,14 +97,20 @@ const NavigationBar = () => {
 
   const studentActions = [];
 
-  if (courseContext.userHasPermission(Permission.SubmitAssignment)) {
+  if (
+    courseContext.courseId &&
+    courseContext.userHasPermission(Permission.SubmitAssignment)
+  ) {
     studentActions.push({
       content: 'Realizar nueva entrega',
       action: () => navigate(buildAddSubmissionRoute(courseContext.courseId)),
     });
   }
 
-  if (courseContext.userHasPermission(Permission.ManageOwnGroups)) {
+  if (
+    courseContext.courseId &&
+    courseContext.userHasPermission(Permission.ManageOwnGroups)
+  ) {
     studentActions.push({
       content: 'Gestionar mis grupos',
       action: () => navigate(buildMyGroupsRoute(courseContext.courseId)),
@@ -170,12 +172,14 @@ const NavigationBar = () => {
         }}
       />
 
-      <InviteUserModal
-        isOpen={inviteUserOpen}
-        rootQueryRef={viewerData}
-        onClose={() => setInviteUserOpen(false)}
-        courseId={courseContext.courseId}
-      />
+      {courseContext.courseId && (
+        <InviteUserModal
+          isOpen={inviteUserOpen}
+          rootQueryRef={viewerData}
+          onClose={() => setInviteUserOpen(false)}
+          courseId={courseContext.courseId}
+        />
+      )}
     </HStack>
   );
 };

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -1,19 +1,36 @@
 import { Link } from 'react-router-dom';
 import { HStack } from '@chakra-ui/react';
-import { useUserContext } from 'hooks/useUserCourseContext';
+import { Permission, useUserContext } from 'hooks/useUserCourseContext';
 
-import { buildAssignmentsRoute, buildSubmissionsRoute, buildUsersRoute } from 'routes';
+import {
+  buildMyGroupsRoute,
+  buildAssignmentsRoute,
+  buildSubmissionsRoute,
+  buildUsersRoute,
+} from 'routes';
 
 const Routes = () => {
-  const { courseId } = useUserContext();
+  const { courseId, userIsTeacher, userHasPermission } = useUserContext();
+
   return (
     <HStack pl="10px" spacing="30px">
       <Link to="/courses">Cursos</Link>
       {courseId && (
         <>
           <Link to={buildAssignmentsRoute(courseId)}>Trabajos prácticos</Link>
-          <Link to={buildSubmissionsRoute(courseId)}>Entregas</Link>
           <Link to={buildUsersRoute(courseId)}>Usuarios</Link>
+          {userIsTeacher ? (
+            <>
+              <Link to={buildSubmissionsRoute(courseId)}>Entregas</Link>
+            </>
+          ) : (
+            <>
+              {userHasPermission(Permission.ManageOwnGroups) && (
+                <Link to={buildSubmissionsRoute(courseId)}>Mis entregas</Link>
+              )}
+              <Link to={buildMyGroupsRoute(courseId)}>Mis grupos</Link>
+            </>
+          )}
         </>
       )}
     </HStack>

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -6,7 +6,6 @@ import { buildAssignmentsRoute, buildSubmissionsRoute, buildUsersRoute } from 'r
 
 const Routes = () => {
   const { courseId } = useUserContext();
-
   return (
     <HStack pl="10px" spacing="30px">
       <Link to="/courses">Cursos</Link>

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom';
+import { HStack } from '@chakra-ui/react';
+import { useUserContext } from 'hooks/useUserCourseContext';
+
+import { buildAssignmentsRoute, buildSubmissionsRoute, buildUsersRoute } from 'routes';
+
+const Routes = () => {
+  const { courseId } = useUserContext();
+
+  return (
+    <HStack pl="10px" spacing="30px">
+      <Link to="/courses">Cursos</Link>
+      {courseId && (
+        <>
+          <Link to={buildAssignmentsRoute(courseId)}>Trabajos prácticos</Link>
+          <Link to={buildSubmissionsRoute(courseId)}>Entregas</Link>
+          <Link to={buildUsersRoute(courseId)}>Usuarios</Link>
+        </>
+      )}
+    </HStack>
+  );
+};
+
+export default Routes;

--- a/src/graphql/CourseUsersQuery.tsx
+++ b/src/graphql/CourseUsersQuery.tsx
@@ -21,7 +21,6 @@ export default graphql`
             id
             name
             isTeacher
-            permissions
           }
         }
       }

--- a/src/icons/NextArrowIcon.tsx
+++ b/src/icons/NextArrowIcon.tsx
@@ -3,5 +3,5 @@ import { ChevronRightIcon, IconProps } from '@primer/octicons-react';
 type Props = IconProps;
 
 export default (props: Props) => {
-  return <ChevronRightIcon {...props} size="medium" />;
+  return <ChevronRightIcon size="medium" {...props} />;
 };

--- a/src/layout/SubmitAssignmentContainer.tsx
+++ b/src/layout/SubmitAssignmentContainer.tsx
@@ -216,7 +216,6 @@ function Content({
         ]}
         buttonsEnabled
         onSubmitForm={{ text: 'Enviar', onClick: handleSubmit }}
-        // eslint-disable-next-line
         onCancelForm={{ text: 'Cancelar', onClick: () => navigate('../..') }}
       />
     </>

--- a/src/pages/Invite.tsx
+++ b/src/pages/Invite.tsx
@@ -14,6 +14,7 @@ import { InviteCourseInfoQuery } from '__generated__/InviteCourseInfoQuery.graph
 import InviteCourseInfoQueryDef from 'graphql/InviteCourseInfoQuery';
 import Text from 'components/Text';
 import useToast from 'hooks/useToast';
+import { buildCourseRoute } from 'routes';
 
 const InvitePage = () => {
   const [commitUseInviteMutation] = useMutation<UseInviteMutation>(UseInviteMutationDef);
@@ -43,7 +44,7 @@ const InvitePage = () => {
         } else if (response.useInvite?.courseId) {
           console.log(`Redirecting to /courses/${response.useInvite.courseId}`);
 
-          navigate(`/courses/${response.useInvite.courseId}`);
+          navigate(buildCourseRoute(response.useInvite.courseId));
         }
       },
     });

--- a/src/pages/courses/CreateRepository.tsx
+++ b/src/pages/courses/CreateRepository.tsx
@@ -50,6 +50,7 @@ import { Nullable } from 'types';
 import Spinner from 'components/Spinner';
 import List from 'components/list/List';
 import { TextListItem } from 'components/list/TextListItem';
+import { buildCourseRoute } from 'routes';
 
 type RepositoriesNameConfiguration = {
   prefix: string;
@@ -407,7 +408,7 @@ const CreateRepositoryPage = ({ type }: { type: RepositoryType }) => {
   };
 
   const onCancel = () => {
-    navigate(`/courses/${courseId}`);
+    courseId && navigate(buildCourseRoute(courseId));
   };
 
   const onSubmit = () => {

--- a/src/pages/courses/assignments/create.tsx
+++ b/src/pages/courses/assignments/create.tsx
@@ -7,6 +7,7 @@ import CreateAssignmentMutationDef from 'graphql/CreateAssignmentMutation';
 import useToast from 'hooks/useToast';
 import { useUserContext } from 'hooks/useUserCourseContext';
 import { formatDateAsLocaleIsoString } from 'utils/dates';
+import { buildAssignmentsRoute, buildAssignmentRoute } from 'routes';
 
 import Navigation from 'components/Navigation';
 import Heading from 'components/Heading';
@@ -42,7 +43,7 @@ const CreateAssignmentPage = ({ courseId }: Props) => {
     return errors;
   };
 
-  const onCancel = () => navigate(`..`);
+  const onCancel = () => navigate(buildAssignmentsRoute(courseId));
 
   const onSubmit = (values: InitialValues) => {
     commitCreateAssignment({
@@ -61,7 +62,7 @@ const CreateAssignmentPage = ({ courseId }: Props) => {
             title: 'Trabajo práctico guardado!',
             status: 'success',
           });
-          navigate(`../${data.id}`);
+          navigate(buildAssignmentRoute(courseId, data.id));
         } else {
           const errorMessage = errors ? errors[0].message : null;
           toast({

--- a/src/pages/courses/assignments/index.tsx
+++ b/src/pages/courses/assignments/index.tsx
@@ -25,6 +25,7 @@ import CreateRepositoryIcon from 'icons/CreateRepositoryIcon';
 import GroupIcon from 'icons/GroupIcon';
 import useToast from 'hooks/useToast';
 import RRLink from 'components/RRLink';
+import { buildAssignmentRoute, buildAddAssignmentRoute } from 'routes';
 
 const AssignmentsPage = () => {
   const toast = useToast();
@@ -76,7 +77,10 @@ const AssignmentsPage = () => {
           {courseContext.userHasPermission(Permission.CreateAssignment) && (
             <ButtonWithIcon
               variant={'ghostBorder'}
-              onClick={() => navigate(`create`)}
+              onClick={() =>
+                courseContext.courseId &&
+                navigate(buildAddAssignmentRoute(courseContext.courseId))
+              }
               text={'Crear'}
               icon={CreateIcon}
             />
@@ -100,7 +104,9 @@ const AssignmentsPage = () => {
             return {
               rowProps: {
                 ...ClickableRowPropsConfiguration,
-                onClick: () => navigate(data.id), // Navigate to assignment
+                onClick: () =>
+                  courseContext.courseId &&
+                  navigate(buildAssignmentRoute(courseContext.courseId, data.id)), // Navigate to assignment
               },
               content: [
                 `${data.title}`,

--- a/src/pages/courses/assignments/submissions/index.tsx
+++ b/src/pages/courses/assignments/submissions/index.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useLazyLoadQuery } from 'react-relay';
 

--- a/src/pages/courses/assignments/submissions/index.tsx
+++ b/src/pages/courses/assignments/submissions/index.tsx
@@ -45,6 +45,7 @@ import type {
 } from '__generated__/AssignmentSubmissionsQuery.graphql';
 import { Modal } from 'components/Modal';
 import NotifyModalContent from 'components/SubmissionNotificationModalContent';
+import { buildSubmissionRoute } from 'routes';
 
 type SubmissionType = NonNullable<
   NonNullable<
@@ -225,7 +226,7 @@ const SubmissionsPage = ({ courseContext }: { courseContext: FetchedContext }) =
           submitter: submission.submitter,
           reviewerId: submission.reviewer?.reviewer?.id,
           review: submission.review,
-          submission: submission,
+          submission,
         });
       })
     );
@@ -337,7 +338,7 @@ const SubmissionsPage = ({ courseContext }: { courseContext: FetchedContext }) =
 
   const onRowClick = (rowData: RowData) => {
     rowData.submission?.id
-      ? navigate(rowData.submission?.id)
+      ? navigate(buildSubmissionRoute(courseContext.courseId, rowData.submission?.id))
       : toast({
           title: 'No existe entrega asociada',
           description: 'Para acceder al detalle primero se debe realizar la entrega',

--- a/src/pages/courses/assignments/update.tsx
+++ b/src/pages/courses/assignments/update.tsx
@@ -8,6 +8,7 @@ import AssignmentQueryDef from 'graphql/AssignmentQuery';
 import useToast from 'hooks/useToast';
 import { useUserContext } from 'hooks/useUserCourseContext';
 import { formatDateAsLocaleIsoString } from 'utils/dates';
+import { buildAssignmentRoute } from 'routes';
 
 import Navigation from 'components/Navigation';
 import Heading from 'components/Heading';
@@ -67,7 +68,7 @@ const UpdateAssignmentPage = ({ assignmentId, courseId }: UpdatePageProps) => {
     return errors;
   };
 
-  const onCancel = () => navigate(`..`);
+  const onCancel = () => navigate(buildAssignmentRoute(courseId, assignmentId));
 
   const onSubmit = (values: InitialValues) => {
     commitUpdateAssignment({
@@ -88,7 +89,7 @@ const UpdateAssignmentPage = ({ assignmentId, courseId }: UpdatePageProps) => {
             title: 'Trabajo práctico guardado!',
             status: 'success',
           });
-          navigate(`..`);
+          navigate(buildAssignmentRoute(courseId, assignmentId));
         } else {
           const errorMessage = errors ? errors[0].message : null;
           toast({

--- a/src/pages/courses/course.tsx
+++ b/src/pages/courses/course.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, Suspense, useState } from 'react';
+import { ChangeEvent, Suspense, useState } from 'react';
 import { createSearchParams, useNavigate } from 'react-router-dom';
 import { useLazyLoadQuery, useMutation } from 'react-relay';
 
@@ -38,6 +38,7 @@ import CourseSetDescriptionMutationDef from 'graphql/CourseSetDescriptionMutatio
 
 import useToast from 'hooks/useToast';
 import { CourseContext, Permission, useUserContext } from 'hooks/useUserCourseContext';
+import { buildUsersRoute, buildAssignmentsRoute } from 'routes';
 
 import type {
   CourseInfoQuery,
@@ -163,7 +164,7 @@ const CourseStatistics = ({ course, courseContext, availableOrganizations }: Pro
         icon={<PersonIcon size="large" />}
       />
       <StatCard
-        onClick={() => navigate('assignments')}
+        onClick={() => navigate(buildAssignmentsRoute(course.id))}
         title="Trabajos Prácticos"
         stat={String(course.assignments.length)}
         icon={<TerminalIcon size="large" />}

--- a/src/pages/courses/index.tsx
+++ b/src/pages/courses/index.tsx
@@ -11,6 +11,8 @@ import Navigation from 'components/Navigation';
 import Card from 'components/Card';
 import PageDataContainer from 'components/PageDataContainer';
 
+import { buildCourseRoute } from 'routes';
+
 import UserCoursesQueryDef from 'graphql/UserCoursesQuery';
 import {
   UserCoursesQuery,
@@ -43,9 +45,8 @@ const CourseCard = ({ userRole }: { userRole: UserRole }) => {
 
   const subjectTitle = [subjectCode, subjectName].join(' - ');
 
-  const handleCardClick = (_: MouseEvent<HTMLDivElement>) => {
-    navigate(`/courses/${userRole.course?.id}`);
-  };
+  const handleCardClick = (_: MouseEvent<HTMLDivElement>) =>
+    navigate(buildCourseRoute(userRole.course?.id));
 
   const CARD_TEXT_FONT_SIZE = theme.styles.global.body.fontSize;
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,23 @@
+export const buildCoursesRoute = () => '/courses';
+export const buildLoginRoute = () => '/login';
+
+export const buildCourseRoute = (courseId: string) => `/courses/${courseId}`;
+
+export const buildAddAssignmentRoute = (courseId: string) =>
+  `/courses/${courseId}/assignments/create`;
+export const buildEditAssignmentRoute = (courseId: string) =>
+  `/courses/${courseId}/assignments/edit`;
+export const buildAddSubmissionRoute = (courseId: string) =>
+  `/courses/${courseId}/add-submissions`;
+
+export const buildAssignmentRoute = (courseId: string, assignmentId: string) =>
+  `/courses/${courseId}/assignments/${assignmentId}`;
+
+export const buildSubmissionRoute = (courseId: string, submissionId: string) =>
+  `/courses/${courseId}/submissions/${submissionId}`;
+export const buildMyGroupsRoute = (courseId: string) => `/courses/${courseId}/my-groups`;
+export const buildAssignmentsRoute = (courseId: string) =>
+  `/courses/${courseId}/assignments`;
+export const buildSubmissionsRoute = (courseId: string) =>
+  `/courses/${courseId}/submissions`;
+export const buildUsersRoute = (courseId: string) => `/courses/${courseId}/users`;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,23 +1,33 @@
 export const buildCoursesRoute = () => '/courses';
+
 export const buildLoginRoute = () => '/login';
 
-export const buildCourseRoute = (courseId: string) => `/courses/${courseId}`;
+export const buildCourseRoute = (courseId: string) =>
+  `${buildCoursesRoute()}/${courseId}`;
+
+export const buildAssignmentsRoute = (courseId: string) =>
+  `${buildCourseRoute(courseId)}/assignments`;
+
+export const buildSubmissionsRoute = (courseId: string) =>
+  `${buildCourseRoute(courseId)}/submissions`;
+
+export const buildUsersRoute = (courseId: string) =>
+  `${buildCourseRoute(courseId)}/users`;
 
 export const buildAddAssignmentRoute = (courseId: string) =>
-  `/courses/${courseId}/assignments/create`;
+  `${buildAssignmentsRoute(courseId)}/create`;
+
 export const buildEditAssignmentRoute = (courseId: string) =>
-  `/courses/${courseId}/assignments/edit`;
+  `${buildAssignmentsRoute(courseId)}/edit`;
+
 export const buildAddSubmissionRoute = (courseId: string) =>
-  `/courses/${courseId}/add-submissions`;
+  `${buildCourseRoute(courseId)}/add-submission`;
 
 export const buildAssignmentRoute = (courseId: string, assignmentId: string) =>
-  `/courses/${courseId}/assignments/${assignmentId}`;
+  `${buildAssignmentsRoute(courseId)}/${assignmentId}`;
 
 export const buildSubmissionRoute = (courseId: string, submissionId: string) =>
-  `/courses/${courseId}/submissions/${submissionId}`;
-export const buildMyGroupsRoute = (courseId: string) => `/courses/${courseId}/my-groups`;
-export const buildAssignmentsRoute = (courseId: string) =>
-  `/courses/${courseId}/assignments`;
-export const buildSubmissionsRoute = (courseId: string) =>
-  `/courses/${courseId}/submissions`;
-export const buildUsersRoute = (courseId: string) => `/courses/${courseId}/users`;
+  `${buildSubmissionsRoute(courseId)}/${submissionId}`;
+
+export const buildMyGroupsRoute = (courseId: string) =>
+  `${buildCourseRoute(courseId)}/my-groups`;


### PR DESCRIPTION
Al final no me mandé con los breadcrumbs porque iba a ocupar mucho, y además tenía bastante lógica (teníamos que definir una forma de "fetchear" la data solo para mostrarla en el navegador. 

Me mandé solamente agregando las secciones principales a todos los tipos de usuarios

Sobre **Entregas** lo que tengo pensado hacer es que se devuelvan solo las propias cuando sos alumno, así no mostramos información de otras personas. Por más que sea 1 sola por TP me parece que tiene sentido.

<img width="1800" alt="image" src="https://github.com/teach-hub/frontoffice/assets/44705155/545248b9-1e94-482c-8256-22250e40c45d">
