### PR TITLE
[No ticket] - Update navigation options

### DIFF
--- a/src/__generated__/CourseContextQuery.graphql.ts
+++ b/src/__generated__/CourseContextQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ac30834744b7a88ec81f4b7a99cdaebd>>
+ * @generated SignedSource<<d5691d79e04d2d10a8986d12bd79106e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,10 @@ export type CourseContextQuery$data = {
   readonly viewer: {
     readonly course: {
       readonly id: string;
+      readonly subject: {
+        readonly id: string;
+        readonly name: string;
+      };
       readonly viewerRole: {
         readonly id: string;
         readonly isTeacher: boolean;
@@ -46,7 +50,14 @@ v1 = {
   "name": "id",
   "storageKey": null
 },
-v2 = [
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = [
   {
     "alias": null,
     "args": null,
@@ -74,19 +85,26 @@ v2 = [
           {
             "alias": null,
             "args": null,
+            "concreteType": "SubjectType",
+            "kind": "LinkedField",
+            "name": "subject",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "RoleType",
             "kind": "LinkedField",
             "name": "viewerRole",
             "plural": false,
             "selections": [
               (v1/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "name",
-                "storageKey": null
-              },
+              (v2/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -117,7 +135,7 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "CourseContextQuery",
-    "selections": (v2/*: any*/),
+    "selections": (v3/*: any*/),
     "type": "RootQueryType",
     "abstractKey": null
   },
@@ -126,19 +144,19 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "CourseContextQuery",
-    "selections": (v2/*: any*/)
+    "selections": (v3/*: any*/)
   },
   "params": {
-    "cacheID": "1d7920c1d15d276ed07c8f9c30643eaf",
+    "cacheID": "557ae47ebab5b9067163a6c5c8873732",
     "id": null,
     "metadata": {},
     "name": "CourseContextQuery",
     "operationKind": "query",
-    "text": "query CourseContextQuery(\n  $courseId: ID!\n) {\n  viewer {\n    id\n    course(id: $courseId) {\n      id\n      viewerRole {\n        id\n        name\n        permissions\n        isTeacher\n      }\n    }\n  }\n}\n"
+    "text": "query CourseContextQuery(\n  $courseId: ID!\n) {\n  viewer {\n    id\n    course(id: $courseId) {\n      id\n      subject {\n        id\n        name\n      }\n      viewerRole {\n        id\n        name\n        permissions\n        isTeacher\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ca1c0562b55b5d643b0ab9fd537fe25b";
+(node as any).hash = "8b6894adcecbb67252c8e8b3cf0a3b70";
 
 export default node;

--- a/src/__generated__/CourseUsersQuery.graphql.ts
+++ b/src/__generated__/CourseUsersQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<86a4adfa6dae12861c374853380e24b5>>
+ * @generated SignedSource<<b90e7e212cd1810009c30e269a01af6c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,7 +23,6 @@ export type CourseUsersQuery$data = {
           readonly id: string;
           readonly isTeacher: boolean;
           readonly name: string;
-          readonly permissions: ReadonlyArray<string | null> | null;
         };
         readonly user: {
           readonly file: string;
@@ -151,13 +150,6 @@ v3 = [
                     "kind": "ScalarField",
                     "name": "isTeacher",
                     "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "permissions",
-                    "storageKey": null
                   }
                 ],
                 "storageKey": null
@@ -190,16 +182,16 @@ return {
     "selections": (v3/*: any*/)
   },
   "params": {
-    "cacheID": "49ecd5d983b989167256cfe6c5e921b3",
+    "cacheID": "ca07a114684cb6002eca87da08d40920",
     "id": null,
     "metadata": {},
     "name": "CourseUsersQuery",
     "operationKind": "query",
-    "text": "query CourseUsersQuery(\n  $courseId: ID!\n) {\n  viewer {\n    id\n    name\n    course(id: $courseId) {\n      id\n      name\n      userRoles {\n        id\n        user {\n          id\n          name\n          lastName\n          file\n          notificationEmail\n        }\n        role {\n          id\n          name\n          isTeacher\n          permissions\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query CourseUsersQuery(\n  $courseId: ID!\n) {\n  viewer {\n    id\n    name\n    course(id: $courseId) {\n      id\n      name\n      userRoles {\n        id\n        user {\n          id\n          name\n          lastName\n          file\n          notificationEmail\n        }\n        role {\n          id\n          name\n          isTeacher\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "8f84a46156ae3b271b20564271b0c77c";
+(node as any).hash = "bd298bf484fc19f7b096de367e7a05db";
 
 export default node;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -15,7 +15,7 @@ import HomeButton from 'components/HomeButton';
 import Routes from 'components/Routes';
 
 import { theme } from 'theme';
-import { buildMyGroupsRoute, buildAddSubmissionRoute } from 'routes';
+import { buildAddSubmissionRoute } from 'routes';
 
 import { storeGetValue, storeRemoveValue } from 'hooks/useLocalStorage';
 import { Permission, useUserContext } from 'hooks/useUserCourseContext';
@@ -90,7 +90,7 @@ const NavigationBar = () => {
 
   if (courseContext.userHasPermission(Permission.InviteUser)) {
     teacherActions.push({
-      content: 'Invitar usuario',
+      content: 'Invitar usuarios',
       action: () => setInviteUserOpen(v => !v),
     });
   }

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -1,22 +1,24 @@
-import { Link } from 'react-router-dom';
 import { HStack } from '@chakra-ui/react';
 import { Permission, useUserContext } from 'hooks/useUserCourseContext';
 
 import {
-  buildMyGroupsRoute,
   buildAssignmentsRoute,
+  buildCourseRoute,
+  buildMyGroupsRoute,
   buildSubmissionsRoute,
   buildUsersRoute,
 } from 'routes';
+import Link from 'components/RRLink';
 
 const Routes = () => {
-  const { courseId, userIsTeacher, userHasPermission } = useUserContext();
+  const { courseId, subjectName, userIsTeacher, userHasPermission } = useUserContext();
 
   return (
     <HStack pl="10px" spacing="30px">
-      <Link to="/courses">Cursos</Link>
+      <Link to="/courses">Mis cursos</Link>
       {courseId && (
         <>
+          <Link to={buildCourseRoute(courseId)}>{subjectName}</Link>
           <Link to={buildAssignmentsRoute(courseId)}>Trabajos prácticos</Link>
           <Link to={buildUsersRoute(courseId)}>Usuarios</Link>
           {userIsTeacher ? (

--- a/src/graphql/CourseContextQuery.tsx
+++ b/src/graphql/CourseContextQuery.tsx
@@ -6,6 +6,10 @@ export default graphql`
       id
       course(id: $courseId) {
         id
+        subject {
+          id
+          name
+        }
         viewerRole {
           id
           name

--- a/src/hooks/useUserCourseContext.tsx
+++ b/src/hooks/useUserCourseContext.tsx
@@ -29,6 +29,7 @@ export enum Permission {
 
 export type EmptyContext = {
   courseId: null;
+  subjectName: null;
   userPermissions: never[];
   userIsTeacher: null;
   userHasPermission: (p: Permission) => boolean;
@@ -36,6 +37,7 @@ export type EmptyContext = {
 
 export type FetchedContext = {
   courseId: string;
+  subjectName: string;
   userPermissions: string[];
   userIsTeacher: boolean;
   userHasPermission: (p: Permission) => boolean;
@@ -49,6 +51,7 @@ const _noop = () => false;
 // https://legacy.reactjs.org/docs/context.html#reactcreatecontext
 const defaultUserContext: CourseContext = {
   courseId: null,
+  subjectName: null,
   userIsTeacher: null,
   userPermissions: [],
   userHasPermission: _noop,
@@ -74,6 +77,7 @@ const Provider = ({
 
   const [courseContext] = useState<CourseContext>({
     courseId,
+    subjectName: courseContextData.viewer?.course?.subject?.name ?? '',
     userIsTeacher: viewerCourseRole?.isTeacher ?? false,
     userPermissions: viewerCoursePermissions ?? [],
     userHasPermission: (p: Permission) => {


### PR DESCRIPTION
Usando la navegacion nueva me pareció que faltaba alguna forma de volver al home del curso. Con eso actualice otras cosas, revisables:
- Cambie **Cursos** por **Mis cursos**, wording nomas
- Cambie el componente que usan los links para que se resalten como el resto de los links cuando le pasas el mouse por arriba
- Le agregue una opcion para volver al inicio del curso actual. Lo que hice, porque tenemos los datos facil, es que esa seccion te diga el nombre del curso. Lo primero que se me ocurrió fue ponerle Inicio/Home o similar, pero se me hacia raro que fuese la segunda opcion volver al "home", y la primera mis cursos. Para mi la mejor forma de organizarlo es volar la opcion de **Mis cursos**, eliminando la pantalla de home y que clickear sobre el logo sea lo que te lleva a mis cursos, que es lo que hace el otro PR. Ahi se podria pasar a llamar **Inicio** (quizas) en lugar de usar el nombre de la materia

![image](https://github.com/teach-hub/frontoffice/assets/31221128/14bb4c50-56c3-4798-a5b8-75d6d07efcbc)
