### PR TITLE
TH-227 Handle long repositories name

### DIFF
--- a/src/pages/courses/CreateRepository.tsx
+++ b/src/pages/courses/CreateRepository.tsx
@@ -146,6 +146,25 @@ interface RepositoriesTypePageConfiguration {
   tableRowData: SelectionTableRowProps[];
 }
 
+/**
+ * Concatenates all non--null strings received
+ * and cleans the resulting string so that is a valid
+ * repository name.
+ *
+ * It will remove access and special characters, as well
+ * as limiting the lenght of the string
+ * */
+const joinStringsAndBuildRepoName = (data: Nullable<string>[]) => {
+  const repoName = data
+    .filter(item => item !== null)
+    .join('_')
+    .toLowerCase();
+
+  const START_INDEX = 0;
+  const END_INDEX = 100;
+  return removeAccentsAndSpecialCharacters(repoName).substring(START_INDEX, END_INDEX);
+};
+
 const buildStudentRepositoryPageConfiguration = ({
   students,
 }: {
@@ -180,16 +199,11 @@ const buildStudentRepositoryPageConfiguration = ({
           getRepoName: (repositoryData: RepositoriesNameConfiguration) => {
             const { prefix, useLastName, useFile } = repositoryData;
 
-            const repoName = [
+            return joinStringsAndBuildRepoName([
               prefix || null,
               useLastName ? student.user.lastName : null,
               useFile ? student.user.file : null,
-            ]
-              .filter(item => item !== null)
-              .join('_')
-              .toLowerCase();
-
-            return removeAccentsAndSpecialCharacters(repoName);
+            ]);
           },
         };
       })
@@ -246,17 +260,12 @@ const buildGroupRepositoryPageConfiguration = ({
             ? users.map(({ user }) => user.lastName).join('_')
             : null;
           const files = useFile ? users.map(({ user }) => user.file).join('_') : null;
-          const repoName = [
+          return joinStringsAndBuildRepoName([
             prefix || null,
             useGroupName ? groupName : null,
             lastNames,
             files,
-          ]
-            .filter(item => item !== null)
-            .join('_')
-            .toLowerCase();
-
-          return removeAccentsAndSpecialCharacters(repoName);
+          ]);
         },
       };
     })
@@ -515,6 +524,9 @@ const CreateRepositoryPage = ({ type }: { type: RepositoryType }) => {
             isInvalid={errorInRepositoryName}
             errorMessage={
               'No es posible crear repositorios sin nombre, revisar configuración'
+            }
+            helperText={
+              'Nota: la longitud máxima para el nombre de un repositorio es de 100 caracteres. En caso de que en algún repositorio se supere esa longitud, se recortará el mismo'
             }
           >
             <InputField


### PR DESCRIPTION
Lo maneje desde front que me parecia lo mas facil y claro tambien para el usuario.

Agregue un mensaje para que el usuario sepa que vamos a recortar el largo en caso de que el nombre de un repo supere 100 caracteres

![image](https://github.com/teach-hub/frontoffice/assets/31221128/ae6fecf2-4158-4766-8bf0-003c00c0023e)
