### PR TITLE
TH-229 Handle empty charts

### DIFF
--- a/src/components/charts/Pie.tsx
+++ b/src/components/charts/Pie.tsx
@@ -1,15 +1,16 @@
 import { ChartProps, Pie as ChartJsPie } from 'react-chartjs-2';
 import { theme } from 'theme';
 import React from 'react';
-import { LayoutPosition } from 'chart.js';
+import { Chart, LayoutPosition } from 'chart.js';
+import { ChartPluginName, configureNoDataPlugin } from 'components/charts/chartPlugins';
 
-type ChartData<T> = {
+type ChartData = {
   label: string;
-  data: T[];
+  data: number[];
   backgroundColors: string[];
 };
 
-export const Pie = <T,>({
+export const Pie = ({
   labels,
   data,
   props,
@@ -18,11 +19,17 @@ export const Pie = <T,>({
 }: {
   title: string;
   labels: string[];
-  data: ChartData<T>;
+  data: ChartData;
   props?: ChartProps;
   horizontal?: boolean;
   legendPosition?: LayoutPosition;
 }) => {
+  const emptyChart = () => {
+    const emptyLabels = labels.length === 0;
+    const emptyData = data.data.every(d => d === 0);
+    return emptyLabels || emptyData;
+  };
+
   const chartData = {
     labels,
     datasets: [
@@ -50,7 +57,7 @@ export const Pie = <T,>({
             },
           },
           legend: {
-            display: true,
+            display: !emptyChart(), // Only show legends if chart is not empty
             labels: {
               font: {
                 size: FONT_SIZE,
@@ -60,6 +67,14 @@ export const Pie = <T,>({
           },
         },
       }}
+      plugins={[
+        {
+          id: ChartPluginName.NoDataPieChart,
+          beforeDraw: (chart: Chart) => {
+            if (emptyChart()) configureNoDataPlugin(chart);
+          },
+        },
+      ]}
     />
   );
 };

--- a/src/components/charts/StackedBarChart.tsx
+++ b/src/components/charts/StackedBarChart.tsx
@@ -1,5 +1,7 @@
 import { Bar, ChartProps } from 'react-chartjs-2';
 import { theme } from 'theme';
+import { Chart } from 'chart.js';
+import { ChartPluginName, configureNoDataPlugin } from 'components/charts/chartPlugins';
 
 type ChartData<T> = {
   label: string;
@@ -20,6 +22,12 @@ export const StackedBarChart = <T,>({
   props?: ChartProps;
   horizontal?: boolean;
 }) => {
+  const emptyChart = () => {
+    const emptyLabels = labels.length === 0;
+    const emptyData = data.length === 0 || data.every(d => d.data.length === 0);
+    return emptyLabels || emptyData;
+  };
+
   const formatTick = (tick: string) => {
     const LABEL_MAX_LENGTH = 30;
     if (tick.length > LABEL_MAX_LENGTH) {
@@ -90,6 +98,14 @@ export const StackedBarChart = <T,>({
           },
         },
       }}
+      plugins={[
+        {
+          id: ChartPluginName.NoDataStackedBarChart,
+          afterDraw: (chart: Chart) => {
+            if (emptyChart()) configureNoDataPlugin(chart);
+          },
+        },
+      ]}
     />
   );
 };

--- a/src/components/charts/chartPlugins.tsx
+++ b/src/components/charts/chartPlugins.tsx
@@ -1,0 +1,21 @@
+import { theme } from 'theme';
+import { Chart } from 'chart.js';
+
+export enum ChartPluginName {
+  NoDataPieChart = 'noDataPieChart',
+  NoDataStackedBarChart = 'noDataStackedBarChart',
+}
+
+export const configureNoDataPlugin = (chart: Chart) => {
+  const ctx = chart.ctx;
+  const width = chart.width;
+  const height = chart.height;
+
+  ctx.save();
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.font = '26px Arial';
+  ctx.fillStyle = theme.colors.teachHub.gray;
+  ctx.fillText('No hay datos', width / 2, height / 2);
+  ctx.restore();
+};


### PR DESCRIPTION
Se agrega configuración que nos deja manejar los casos donde los charts quedan vacios, y poner algun texto en lugar de un grafico vacio para que sea mas "lindo" al usuario

Ejemplo a nivel curso
![image](https://github.com/teach-hub/frontoffice/assets/31221128/c30239ed-f24b-4187-8ba7-79d9076d0118)

Ejemplo a nivel detalle de tp
![image](https://github.com/teach-hub/frontoffice/assets/31221128/8aba05cd-a89d-4b66-9821-ea3f60445c78)
